### PR TITLE
feat(ui): Scoffold high-level components

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,8 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
+/** @typedef {import('ts-jest').JestConfigWithTsJest} JestConfigWithTsJest */
 
 const modules = ['@mui', '@babel'].join('|')
 
+/** @type {JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
@@ -15,4 +16,5 @@ module.exports = {
     ],
     '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/src/__mocks__/fileMock.js',
   },
+  setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@storybook/react-vite": "^7.6.4",
         "@storybook/testing-library": "^0.2.2",
         "@testing-library/dom": "^9.3.3",
+        "@testing-library/jest-dom": "^6.1.6",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.5.1",
         "@types/jest": "^29.5.3",
@@ -79,6 +80,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -7962,6 +7969,60 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.6.tgz",
+      "integrity": "sha512-YwuiOdYEcxhfC2u5iNKlvg2Q5MgbutovP6drq7J1HrCbvR+G58BbtoCoq+L/kNlrNFsu2Kt3jaFAviLVxYHJZg==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.3.2",
+        "@babel/runtime": "^7.9.2",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">= 28",
+        "@types/jest": ">= 28",
+        "jest": ">= 28",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@testing-library/react": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
@@ -10346,6 +10407,12 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
     },
     "node_modules/csso": {
       "version": "5.0.5",
@@ -16832,6 +16899,31 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regenerate": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@storybook/react-vite": "^7.6.4",
     "@storybook/testing-library": "^0.2.2",
     "@testing-library/dom": "^9.3.3",
+    "@testing-library/jest-dom": "^6.1.6",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.3",

--- a/src/app/components/Card/CardCropText.tsx
+++ b/src/app/components/Card/CardCropText.tsx
@@ -1,6 +1,6 @@
 import Typography from '@mui/material/Typography'
 
-import { ICrop, IPlayedCrop } from '../../../game/types/index'
+import { ICrop, IPlayedCrop } from '../../../game/types'
 
 export const CardCropText = ({
   crop,

--- a/src/app/components/Deck/Deck.stories.ts
+++ b/src/app/components/Deck/Deck.stories.ts
@@ -21,7 +21,7 @@ const game = stubGame()
 
 export const SelfDeck: Story = {
   args: {
-    playerId: game.userPlayerId,
+    playerId: game.sessionOwnerPlayerId,
     game,
   },
 }

--- a/src/app/components/Deck/Deck.stories.ts
+++ b/src/app/components/Deck/Deck.stories.ts
@@ -2,17 +2,17 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { stubGame } from '../../../test-utils/stubs/game'
 
-import { Field } from './Field'
+import { Deck } from './Deck'
 
 const meta = {
-  title: 'Farmhand Shuffle/Field',
-  component: Field,
+  title: 'Farmhand Shuffle/Deck',
+  component: Deck,
   parameters: {
     layout: 'centered',
   },
   tags: ['autodocs'],
   argTypes: {},
-} satisfies Meta<typeof Field>
+} satisfies Meta<typeof Deck>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/src/app/components/Deck/Deck.tsx
+++ b/src/app/components/Deck/Deck.tsx
@@ -3,12 +3,12 @@ import Box, { BoxProps } from '@mui/material/Box'
 import { InvalidIdError } from '../../../game/services/Rules/errors'
 import { IGame, IPlayer } from '../../../game/types'
 
-export interface FieldProps extends BoxProps {
+export interface DeckProps extends BoxProps {
   game: IGame
   playerId: IPlayer['id']
 }
 
-export const Field = ({ playerId, game, ...rest }: FieldProps) => {
+export const Deck = ({ playerId, game, ...rest }: DeckProps) => {
   const player = game.table.players[playerId]
 
   if (!player) {
@@ -19,7 +19,7 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
 
   return (
     <Box {...rest} data-testid={`field_${playerId}`}>
-      {JSON.stringify(player, null, 2)}
+      {JSON.stringify(player.deck, null, 2)}
     </Box>
   )
 }

--- a/src/app/components/Deck/Deck.tsx
+++ b/src/app/components/Deck/Deck.tsx
@@ -18,7 +18,7 @@ export const Deck = ({ playerId, game, ...rest }: DeckProps) => {
   }
 
   return (
-    <Box {...rest} data-testid={`field_${playerId}`}>
+    <Box {...rest} data-testid={`deck_${playerId}`}>
       {JSON.stringify(player.deck, null, 2)}
     </Box>
   )

--- a/src/app/components/Deck/Deck.tsx
+++ b/src/app/components/Deck/Deck.tsx
@@ -1,6 +1,6 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
-import { InvalidIdError } from '../../../game/services/Rules/errors'
+import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
 
 export interface DeckProps extends BoxProps {
@@ -9,13 +9,7 @@ export interface DeckProps extends BoxProps {
 }
 
 export const Deck = ({ playerId, game, ...rest }: DeckProps) => {
-  const player = game.table.players[playerId]
-
-  if (!player) {
-    throw new InvalidIdError(
-      `playerId ${playerId} does not correspond to any players in the game.`
-    )
-  }
+  const player = lookup.getPlayer(game, playerId)
 
   return (
     <Box {...rest} data-testid={`deck_${playerId}`}>

--- a/src/app/components/Deck/index.tsx
+++ b/src/app/components/Deck/index.tsx
@@ -1,0 +1,1 @@
+export * from './Deck'

--- a/src/app/components/DiscardPile/DiscardPile.stories.ts
+++ b/src/app/components/DiscardPile/DiscardPile.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { stubGame } from '../../../test-utils/stubs/game'
+
+import { DiscardPile } from './DiscardPile'
+
+const meta = {
+  title: 'Farmhand Shuffle/Discard Pile',
+  component: DiscardPile,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof DiscardPile>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const game = stubGame()
+
+export const SelfDiscardPile: Story = {
+  args: {
+    playerId: game.userPlayerId,
+    game,
+  },
+}

--- a/src/app/components/DiscardPile/DiscardPile.stories.ts
+++ b/src/app/components/DiscardPile/DiscardPile.stories.ts
@@ -21,7 +21,7 @@ const game = stubGame()
 
 export const SelfDiscardPile: Story = {
   args: {
-    playerId: game.userPlayerId,
+    playerId: game.sessionOwnerPlayerId,
     game,
   },
 }

--- a/src/app/components/DiscardPile/DiscardPile.tsx
+++ b/src/app/components/DiscardPile/DiscardPile.tsx
@@ -1,0 +1,25 @@
+import Box, { BoxProps } from '@mui/material/Box'
+
+import { InvalidIdError } from '../../../game/services/Rules/errors'
+import { IGame, IPlayer } from '../../../game/types'
+
+export interface DiscardPileProps extends BoxProps {
+  game: IGame
+  playerId: IPlayer['id']
+}
+
+export const DiscardPile = ({ playerId, game, ...rest }: DiscardPileProps) => {
+  const player = game.table.players[playerId]
+
+  if (!player) {
+    throw new InvalidIdError(
+      `playerId ${playerId} does not correspond to any players in the game.`
+    )
+  }
+
+  return (
+    <Box {...rest} data-testid={`discard-pile_${playerId}`}>
+      {JSON.stringify(player.discardPile, null, 2)}
+    </Box>
+  )
+}

--- a/src/app/components/DiscardPile/DiscardPile.tsx
+++ b/src/app/components/DiscardPile/DiscardPile.tsx
@@ -1,6 +1,6 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
-import { InvalidIdError } from '../../../game/services/Rules/errors'
+import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
 
 export interface DiscardPileProps extends BoxProps {
@@ -9,13 +9,7 @@ export interface DiscardPileProps extends BoxProps {
 }
 
 export const DiscardPile = ({ playerId, game, ...rest }: DiscardPileProps) => {
-  const player = game.table.players[playerId]
-
-  if (!player) {
-    throw new InvalidIdError(
-      `playerId ${playerId} does not correspond to any players in the game.`
-    )
-  }
+  const player = lookup.getPlayer(game, playerId)
 
   return (
     <Box {...rest} data-testid={`discard-pile_${playerId}`}>

--- a/src/app/components/DiscardPile/index.tsx
+++ b/src/app/components/DiscardPile/index.tsx
@@ -1,0 +1,1 @@
+export * from './DiscardPile'

--- a/src/app/components/Field/Field.stories.ts
+++ b/src/app/components/Field/Field.stories.ts
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>
 
 const game = stubGame()
 
-export const SelfDeck: Story = {
+export const SelfField: Story = {
   args: {
     playerId: game.userPlayerId,
     game,

--- a/src/app/components/Field/Field.stories.ts
+++ b/src/app/components/Field/Field.stories.ts
@@ -21,7 +21,7 @@ const game = stubGame()
 
 export const SelfField: Story = {
   args: {
-    playerId: game.userPlayerId,
+    playerId: game.sessionOwnerPlayerId,
     game,
   },
 }

--- a/src/app/components/Field/Field.stories.ts
+++ b/src/app/components/Field/Field.stories.ts
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { stubGame } from '../../../test-utils/stubs/game'
+
 import { Field } from './Field'
 
 const meta = {
@@ -15,6 +17,11 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const BaseTable: Story = {
-  args: {},
+const game = stubGame()
+
+export const SelfTable: Story = {
+  args: {
+    playerId: game.userPlayerId,
+    game,
+  },
 }

--- a/src/app/components/Field/Field.stories.ts
+++ b/src/app/components/Field/Field.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Field } from './Field'
+
+const meta = {
+  title: 'Farmhand Shuffle/Field',
+  component: Field,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Field>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const BaseTable: Story = {
+  args: {},
+}

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -1,7 +1,22 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
-export interface FieldProps extends BoxProps {}
+import { InvalidIdError } from '../../../game/services/Rules/errors'
 
-export const Field = ({ ...rest }: FieldProps) => {
-  return <Box {...rest}></Box>
+import { IGame, IPlayer } from '../../../game/types/index'
+
+export interface FieldProps extends BoxProps {
+  game: IGame
+  playerId: IPlayer['id']
+}
+
+export const Field = ({ playerId, game, ...rest }: FieldProps) => {
+  const player = game.table.players[playerId]
+
+  if (!player) {
+    throw new InvalidIdError(
+      `playerId ${playerId} does not correspond to any players in the game.`
+    )
+  }
+
+  return <Box {...rest}>{JSON.stringify(player, null, 2)}</Box>
 }

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -1,0 +1,7 @@
+import Box, { BoxProps } from '@mui/material/Box'
+
+export interface FieldProps extends BoxProps {}
+
+export const Field = ({ ...rest }: FieldProps) => {
+  return <Box {...rest}></Box>
+}

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -1,6 +1,6 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
-import { InvalidIdError } from '../../../game/services/Rules/errors'
+import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
 
 export interface FieldProps extends BoxProps {
@@ -9,13 +9,7 @@ export interface FieldProps extends BoxProps {
 }
 
 export const Field = ({ playerId, game, ...rest }: FieldProps) => {
-  const player = game.table.players[playerId]
-
-  if (!player) {
-    throw new InvalidIdError(
-      `playerId ${playerId} does not correspond to any players in the game.`
-    )
-  }
+  const player = lookup.getPlayer(game, playerId)
 
   return (
     <Box {...rest} data-testid={`field_${playerId}`}>

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -18,5 +18,9 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
     )
   }
 
-  return <Box {...rest}>{JSON.stringify(player, null, 2)}</Box>
+  return (
+    <Box {...rest} data-testid={`field_${playerId}`}>
+      {JSON.stringify(player, null, 2)}
+    </Box>
+  )
 }

--- a/src/app/components/Field/index.tsx
+++ b/src/app/components/Field/index.tsx
@@ -1,0 +1,1 @@
+export * from './Field'

--- a/src/app/components/Game/Game.stories.ts
+++ b/src/app/components/Game/Game.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Game } from './Game'
+
+const meta = {
+  title: 'Farmhand Shuffle/Game',
+  component: Game,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Game>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const BaseGame: Story = {
+  args: {},
+}

--- a/src/app/components/Game/Game.stories.ts
+++ b/src/app/components/Game/Game.stories.ts
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { stubGame } from '../../../test-utils/stubs/game'
+
 import { Game } from './Game'
 
 const meta = {
@@ -15,6 +17,10 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+const game = stubGame()
+
 export const BaseGame: Story = {
-  args: {},
+  args: {
+    game,
+  },
 }

--- a/src/app/components/Game/Game.test.tsx
+++ b/src/app/components/Game/Game.test.tsx
@@ -10,7 +10,7 @@ describe('Game', () => {
   test('renders table', () => {
     render(<Game game={game} />)
 
-    const table = screen.getByTestId(`table_${game.userPlayerId}`)
+    const table = screen.getByTestId(`table_${game.sessionOwnerPlayerId}`)
 
     expect(table).toBeInTheDocument()
   })

--- a/src/app/components/Game/Game.test.tsx
+++ b/src/app/components/Game/Game.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+
+import { stubGame } from '../../../test-utils/stubs/game'
+
+import { Game } from './Game'
+
+const game = stubGame()
+
+describe('Game', () => {
+  test('renders table', () => {
+    render(<Game game={game} />)
+
+    const table = screen.getByTestId(`table_${game.userPlayerId}`)
+
+    expect(table).toBeInTheDocument()
+  })
+})

--- a/src/app/components/Game/Game.tsx
+++ b/src/app/components/Game/Game.tsx
@@ -1,0 +1,7 @@
+import Box, { BoxProps } from '@mui/material/Box'
+
+export interface GameProps extends BoxProps {}
+
+export const Game = ({ ...rest }: GameProps) => {
+  return <Box {...rest}></Box>
+}

--- a/src/app/components/Game/Game.tsx
+++ b/src/app/components/Game/Game.tsx
@@ -1,7 +1,11 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
-export interface GameProps extends BoxProps {}
+import { IGame } from '../../../game/types'
 
-export const Game = ({ ...rest }: GameProps) => {
+export interface GameProps extends BoxProps {
+  game: IGame
+}
+
+export const Game = ({ game, ...rest }: GameProps) => {
   return <Box {...rest}></Box>
 }

--- a/src/app/components/Game/Game.tsx
+++ b/src/app/components/Game/Game.tsx
@@ -1,11 +1,16 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
 import { IGame } from '../../../game/types'
+import { Table } from '../Table/Table'
 
 export interface GameProps extends BoxProps {
   game: IGame
 }
 
 export const Game = ({ game, ...rest }: GameProps) => {
-  return <Box {...rest}></Box>
+  return (
+    <Box {...rest}>
+      <Table game={game} />
+    </Box>
+  )
 }

--- a/src/app/components/Game/index.tsx
+++ b/src/app/components/Game/index.tsx
@@ -1,0 +1,1 @@
+export * from './Game'

--- a/src/app/components/Hand/Hand.stories.ts
+++ b/src/app/components/Hand/Hand.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { stubGame } from '../../../test-utils/stubs/game'
+
+import { Hand } from './Hand'
+
+const meta = {
+  title: 'Farmhand Shuffle/Hand',
+  component: Hand,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Hand>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const game = stubGame()
+
+export const SelfHand: Story = {
+  args: {
+    playerId: game.userPlayerId,
+    game,
+  },
+}

--- a/src/app/components/Hand/Hand.stories.ts
+++ b/src/app/components/Hand/Hand.stories.ts
@@ -21,7 +21,7 @@ const game = stubGame()
 
 export const SelfHand: Story = {
   args: {
-    playerId: game.userPlayerId,
+    playerId: game.sessionOwnerPlayerId,
     game,
   },
 }

--- a/src/app/components/Hand/Hand.tsx
+++ b/src/app/components/Hand/Hand.tsx
@@ -1,6 +1,6 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
-import { InvalidIdError } from '../../../game/services/Rules/errors'
+import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
 
 export interface HandProps extends BoxProps {
@@ -9,13 +9,7 @@ export interface HandProps extends BoxProps {
 }
 
 export const Hand = ({ playerId, game, ...rest }: HandProps) => {
-  const player = game.table.players[playerId]
-
-  if (!player) {
-    throw new InvalidIdError(
-      `playerId ${playerId} does not correspond to any players in the game.`
-    )
-  }
+  const player = lookup.getPlayer(game, playerId)
 
   return (
     <Box {...rest} data-testid={`hand_${playerId}`}>

--- a/src/app/components/Hand/Hand.tsx
+++ b/src/app/components/Hand/Hand.tsx
@@ -1,0 +1,25 @@
+import Box, { BoxProps } from '@mui/material/Box'
+
+import { InvalidIdError } from '../../../game/services/Rules/errors'
+import { IGame, IPlayer } from '../../../game/types'
+
+export interface HandProps extends BoxProps {
+  game: IGame
+  playerId: IPlayer['id']
+}
+
+export const Hand = ({ playerId, game, ...rest }: HandProps) => {
+  const player = game.table.players[playerId]
+
+  if (!player) {
+    throw new InvalidIdError(
+      `playerId ${playerId} does not correspond to any players in the game.`
+    )
+  }
+
+  return (
+    <Box {...rest} data-testid={`hand_${playerId}`}>
+      {JSON.stringify(player.hand, null, 2)}
+    </Box>
+  )
+}

--- a/src/app/components/Hand/index.tsx
+++ b/src/app/components/Hand/index.tsx
@@ -1,0 +1,1 @@
+export * from './Hand'

--- a/src/app/components/Table/Table.stories.ts
+++ b/src/app/components/Table/Table.stories.ts
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { stubGame } from '../../../test-utils/stubs/game'
+
 import { Table } from './Table'
 
 const meta = {
@@ -15,6 +17,10 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+const game = stubGame()
+
 export const BaseTable: Story = {
-  args: {},
+  args: {
+    game,
+  },
 }

--- a/src/app/components/Table/Table.stories.ts
+++ b/src/app/components/Table/Table.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Table } from './Table'
+
+const meta = {
+  title: 'Farmhand Shuffle/Table',
+  component: Table,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Table>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const BaseTable: Story = {
+  args: {},
+}

--- a/src/app/components/Table/Table.test.tsx
+++ b/src/app/components/Table/Table.test.tsx
@@ -6,11 +6,7 @@ import { stubGame } from '../../../test-utils/stubs/game'
 import { Table, TableProps } from './Table'
 
 const game = stubGame()
-const playerIds = lookup.getOpponentPlayerIds(game)
-
-const opponentPlayerIds = playerIds.filter(
-  playerId => playerId !== game.userPlayerId
-)
+const opponentPlayerIds = lookup.getOpponentPlayerIds(game)
 
 const StubTable = (overrides: Partial<TableProps>) => {
   return <Table game={game} {...overrides} />
@@ -25,7 +21,7 @@ describe('Table', () => {
   })
 
   test.each([opponentPlayerIds])(
-    'renders fields for non-user players',
+    'renders fields for opponent players',
     playerId => {
       render(<StubTable />)
       const field = screen.getByTestId(`field_${playerId}`)

--- a/src/app/components/Table/Table.test.tsx
+++ b/src/app/components/Table/Table.test.tsx
@@ -33,4 +33,11 @@ describe('Table', () => {
       expect(field).toBeInTheDocument()
     }
   )
+
+  test('renders deck for user player', () => {
+    render(<StubTable />)
+    const deck = screen.getByTestId(`deck_${game.userPlayerId}`)
+
+    expect(deck).toBeInTheDocument()
+  })
 })

--- a/src/app/components/Table/Table.test.tsx
+++ b/src/app/components/Table/Table.test.tsx
@@ -1,13 +1,14 @@
 import { render, screen } from '@testing-library/react'
 
+import { lookup } from '../../../game/services/Lookup'
 import { stubGame } from '../../../test-utils/stubs/game'
 
 import { Table, TableProps } from './Table'
 
 const game = stubGame()
-const playerIds = Object.keys(game.table.players)
+const playerIds = lookup.getOpponentPlayerIds(game)
 
-const nonUserPlayers = playerIds.filter(
+const opponentPlayerIds = playerIds.filter(
   playerId => playerId !== game.userPlayerId
 )
 
@@ -23,7 +24,7 @@ describe('Table', () => {
     expect(field).toBeInTheDocument()
   })
 
-  test.each([nonUserPlayers])(
+  test.each([opponentPlayerIds])(
     'renders fields for non-user players',
     playerId => {
       render(<StubTable />)

--- a/src/app/components/Table/Table.test.tsx
+++ b/src/app/components/Table/Table.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+
+import { stubGame } from '../../../test-utils/stubs/game'
+
+import { Table, TableProps } from './Table'
+
+const game = stubGame()
+const playerIds = Object.keys(game.table.players)
+
+const nonUserPlayers = playerIds.filter(
+  playerId => playerId !== game.userPlayerId
+)
+
+const StubTable = (overrides: Partial<TableProps>) => {
+  return <Table game={game} {...overrides} />
+}
+
+describe('Table', () => {
+  test('renders field for user player', () => {
+    render(<StubTable />)
+    const field = screen.getByTestId(`field_${game.userPlayerId}`)
+
+    expect(field).toBeInTheDocument()
+  })
+
+  test.each([nonUserPlayers])(
+    'renders fields for non-user players',
+    playerId => {
+      render(<StubTable />)
+      const field = screen.getByTestId(`field_${playerId}`)
+
+      expect(field).toBeInTheDocument()
+    }
+  )
+})

--- a/src/app/components/Table/Table.test.tsx
+++ b/src/app/components/Table/Table.test.tsx
@@ -47,4 +47,11 @@ describe('Table', () => {
 
     expect(hand).toBeInTheDocument()
   })
+
+  test('renders discard pile for user player', () => {
+    render(<StubTable />)
+    const discardPile = screen.getByTestId(`discard-pile_${game.userPlayerId}`)
+
+    expect(discardPile).toBeInTheDocument()
+  })
 })

--- a/src/app/components/Table/Table.test.tsx
+++ b/src/app/components/Table/Table.test.tsx
@@ -15,7 +15,7 @@ const StubTable = (overrides: Partial<TableProps>) => {
 describe('Table', () => {
   test('renders field for user player', () => {
     render(<StubTable />)
-    const field = screen.getByTestId(`field_${game.userPlayerId}`)
+    const field = screen.getByTestId(`field_${game.sessionOwnerPlayerId}`)
 
     expect(field).toBeInTheDocument()
   })
@@ -32,21 +32,23 @@ describe('Table', () => {
 
   test('renders deck for user player', () => {
     render(<StubTable />)
-    const deck = screen.getByTestId(`deck_${game.userPlayerId}`)
+    const deck = screen.getByTestId(`deck_${game.sessionOwnerPlayerId}`)
 
     expect(deck).toBeInTheDocument()
   })
 
   test('renders hand for user player', () => {
     render(<StubTable />)
-    const hand = screen.getByTestId(`hand_${game.userPlayerId}`)
+    const hand = screen.getByTestId(`hand_${game.sessionOwnerPlayerId}`)
 
     expect(hand).toBeInTheDocument()
   })
 
   test('renders discard pile for user player', () => {
     render(<StubTable />)
-    const discardPile = screen.getByTestId(`discard-pile_${game.userPlayerId}`)
+    const discardPile = screen.getByTestId(
+      `discard-pile_${game.sessionOwnerPlayerId}`
+    )
 
     expect(discardPile).toBeInTheDocument()
   })

--- a/src/app/components/Table/Table.test.tsx
+++ b/src/app/components/Table/Table.test.tsx
@@ -40,4 +40,11 @@ describe('Table', () => {
 
     expect(deck).toBeInTheDocument()
   })
+
+  test('renders hand for user player', () => {
+    render(<StubTable />)
+    const hand = screen.getByTestId(`hand_${game.userPlayerId}`)
+
+    expect(hand).toBeInTheDocument()
+  })
 })

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -3,5 +3,9 @@ import Box, { BoxProps } from '@mui/material/Box'
 export interface TableProps extends BoxProps {}
 
 export const Table = ({ ...rest }: TableProps) => {
+  // FIXME: Render player deck
+  // FIXME: Render player hand
+  // FIXME: Render player discard pile
+  // FIXME: Render player field
   return <Box {...rest}></Box>
 }

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -2,6 +2,7 @@ import Box, { BoxProps } from '@mui/material/Box'
 
 import { lookup } from '../../../game/services/Lookup'
 import { IGame } from '../../../game/types'
+import { Deck } from '../Deck/Deck'
 import { Field } from '../Field/Field'
 
 export interface TableProps extends BoxProps {
@@ -13,7 +14,6 @@ export const Table = ({ game, ...rest }: TableProps) => {
 
   const opponentPlayerIds = lookup.getOpponentPlayerIds(game)
 
-  // FIXME: Render player deck
   // FIXME: Render player hand
   // FIXME: Render player discard pile
 
@@ -23,6 +23,7 @@ export const Table = ({ game, ...rest }: TableProps) => {
       {opponentPlayerIds.map(playerId => {
         return <Field key={playerId} game={game} playerId={playerId} />
       })}
+      <Deck game={game} playerId={userPlayerId} />
     </Box>
   )
 }

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -1,0 +1,7 @@
+import Box, { BoxProps } from '@mui/material/Box'
+
+export interface TableProps extends BoxProps {}
+
+export const Table = ({ ...rest }: TableProps) => {
+  return <Box {...rest}></Box>
+}

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -4,6 +4,7 @@ import { lookup } from '../../../game/services/Lookup'
 import { IGame } from '../../../game/types'
 import { Deck } from '../Deck/Deck'
 import { Field } from '../Field/Field'
+import { Hand } from '../Hand/Hand'
 
 export interface TableProps extends BoxProps {
   game: IGame
@@ -14,7 +15,6 @@ export const Table = ({ game, ...rest }: TableProps) => {
 
   const opponentPlayerIds = lookup.getOpponentPlayerIds(game)
 
-  // FIXME: Render player hand
   // FIXME: Render player discard pile
 
   return (
@@ -24,6 +24,7 @@ export const Table = ({ game, ...rest }: TableProps) => {
         return <Field key={playerId} game={game} playerId={playerId} />
       })}
       <Deck game={game} playerId={userPlayerId} />
+      <Hand game={game} playerId={userPlayerId} />
     </Box>
   )
 }

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -3,6 +3,7 @@ import Box, { BoxProps } from '@mui/material/Box'
 import { lookup } from '../../../game/services/Lookup'
 import { IGame } from '../../../game/types'
 import { Deck } from '../Deck/Deck'
+import { DiscardPile } from '../DiscardPile/DiscardPile'
 import { Field } from '../Field/Field'
 import { Hand } from '../Hand/Hand'
 
@@ -15,8 +16,6 @@ export const Table = ({ game, ...rest }: TableProps) => {
 
   const opponentPlayerIds = lookup.getOpponentPlayerIds(game)
 
-  // FIXME: Render player discard pile
-
   return (
     <Box {...rest}>
       <Field game={game} playerId={userPlayerId} />
@@ -25,6 +24,7 @@ export const Table = ({ game, ...rest }: TableProps) => {
       })}
       <Deck game={game} playerId={userPlayerId} />
       <Hand game={game} playerId={userPlayerId} />
+      <DiscardPile game={game} playerId={userPlayerId} />
     </Box>
   )
 }

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -1,11 +1,37 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
-export interface TableProps extends BoxProps {}
+import { IGame } from '../../../game/types'
+import { Field } from '../Field/Field'
 
-export const Table = ({ ...rest }: TableProps) => {
+export interface TableProps extends BoxProps {
+  game: IGame
+}
+
+export const Table = ({ game, ...rest }: TableProps) => {
+  const { userPlayerId } = game
+
+  // FIXME: Test this
+  const otherPlayers = Object.entries(game.table.players).reduce(
+    (acc: typeof game.table.players, [playerId, player]) => {
+      if (playerId !== userPlayerId) {
+        acc[playerId] = player
+      }
+
+      return acc
+    },
+    {}
+  )
+
   // FIXME: Render player deck
   // FIXME: Render player hand
   // FIXME: Render player discard pile
-  // FIXME: Render player field
-  return <Box {...rest}></Box>
+
+  return (
+    <Box {...rest}>
+      <Field game={game} playerId={userPlayerId} />
+      {Object.keys(otherPlayers).map(playerId => {
+        return <Field key={playerId} game={game} playerId={playerId} />
+      })}
+    </Box>
+  )
 }

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -10,7 +10,7 @@ export interface TableProps extends BoxProps {
 export const Table = ({ game, ...rest }: TableProps) => {
   const { userPlayerId } = game
 
-  // FIXME: Test this
+  // FIXME: Move this to a service
   const otherPlayers = Object.keys(game.table.players).filter(
     playerId => playerId !== userPlayerId
   )

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -17,7 +17,7 @@ export const Table = ({ game, ...rest }: TableProps) => {
   const opponentPlayerIds = lookup.getOpponentPlayerIds(game)
 
   return (
-    <Box {...rest}>
+    <Box {...rest} data-testid={`table_${game.userPlayerId}`}>
       <Field game={game} playerId={userPlayerId} />
       {opponentPlayerIds.map(playerId => {
         return <Field key={playerId} game={game} playerId={playerId} />

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -12,12 +12,12 @@ export interface TableProps extends BoxProps {
 }
 
 export const Table = ({ game, ...rest }: TableProps) => {
-  const { userPlayerId } = game
+  const { sessionOwnerPlayerId: userPlayerId } = game
 
   const opponentPlayerIds = lookup.getOpponentPlayerIds(game)
 
   return (
-    <Box {...rest} data-testid={`table_${game.userPlayerId}`}>
+    <Box {...rest} data-testid={`table_${game.sessionOwnerPlayerId}`}>
       <Field game={game} playerId={userPlayerId} />
       {opponentPlayerIds.map(playerId => {
         return <Field key={playerId} game={game} playerId={playerId} />

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -1,5 +1,6 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
+import { lookup } from '../../../game/services/Lookup'
 import { IGame } from '../../../game/types'
 import { Field } from '../Field/Field'
 
@@ -10,10 +11,7 @@ export interface TableProps extends BoxProps {
 export const Table = ({ game, ...rest }: TableProps) => {
   const { userPlayerId } = game
 
-  // FIXME: Move this to a service
-  const otherPlayers = Object.keys(game.table.players).filter(
-    playerId => playerId !== userPlayerId
-  )
+  const opponentPlayerIds = lookup.getOpponentPlayerIds(game)
 
   // FIXME: Render player deck
   // FIXME: Render player hand
@@ -22,7 +20,7 @@ export const Table = ({ game, ...rest }: TableProps) => {
   return (
     <Box {...rest}>
       <Field game={game} playerId={userPlayerId} />
-      {otherPlayers.map(playerId => {
+      {opponentPlayerIds.map(playerId => {
         return <Field key={playerId} game={game} playerId={playerId} />
       })}
     </Box>

--- a/src/app/components/Table/Table.tsx
+++ b/src/app/components/Table/Table.tsx
@@ -11,15 +11,8 @@ export const Table = ({ game, ...rest }: TableProps) => {
   const { userPlayerId } = game
 
   // FIXME: Test this
-  const otherPlayers = Object.entries(game.table.players).reduce(
-    (acc: typeof game.table.players, [playerId, player]) => {
-      if (playerId !== userPlayerId) {
-        acc[playerId] = player
-      }
-
-      return acc
-    },
-    {}
+  const otherPlayers = Object.keys(game.table.players).filter(
+    playerId => playerId !== userPlayerId
   )
 
   // FIXME: Render player deck
@@ -29,7 +22,7 @@ export const Table = ({ game, ...rest }: TableProps) => {
   return (
     <Box {...rest}>
       <Field game={game} playerId={userPlayerId} />
-      {Object.keys(otherPlayers).map(playerId => {
+      {otherPlayers.map(playerId => {
         return <Field key={playerId} game={game} playerId={playerId} />
       })}
     </Box>

--- a/src/app/components/Table/index.tsx
+++ b/src/app/components/Table/index.tsx
@@ -1,0 +1,1 @@
+export * from './Table'

--- a/src/app/img/index.ts
+++ b/src/app/img/index.ts
@@ -1,4 +1,4 @@
-import { ICard } from '../../game/types/index'
+import { ICard } from '../../game/types'
 
 import carrot from './cards/carrot.png'
 import pumpkin from './cards/pumpkin.png'

--- a/src/game/cards/crops/handlePlayFromHand.ts
+++ b/src/game/cards/crops/handlePlayFromHand.ts
@@ -1,6 +1,6 @@
 import { addCropToField } from '../../reducers/add-crop-to-field'
 import { Factory } from '../../services/Factory'
-import { Lookup } from '../../services/Lookup'
+import { lookup } from '../../services/Lookup'
 import { InvalidCardError } from '../../services/Rules/errors'
 import { InteractionHandlers } from '../../services/Rules/InteractionHandlers'
 import { IGame, IPlayer } from '../../types'
@@ -12,7 +12,7 @@ export const handlePlayFromHand = async (
   playerId: IPlayer['id'],
   cardIdx: number
 ) => {
-  const card = Lookup.getCardFromHand(game, playerId, cardIdx)
+  const card = lookup.getCardFromHand(game, playerId, cardIdx)
 
   if (!isCrop(card)) {
     throw new InvalidCardError(`${card.id} is not a crop card.`)

--- a/src/game/services/Factory/index.ts
+++ b/src/game/services/Factory/index.ts
@@ -33,19 +33,21 @@ export class Factory {
 
   static buildGame(
     overrides: Partial<IGame> = {},
-    userPlayerId = uuid()
+    sessionOwnerPlayerId = uuid()
   ): IGame {
     const table = Factory.buildTable(overrides?.table)
     const { players } = table
 
     if (Object.keys(players).length === 0) {
-      players[userPlayerId] = this.buildPlayer({ id: userPlayerId })
+      players[sessionOwnerPlayerId] = this.buildPlayer({
+        id: sessionOwnerPlayerId,
+      })
     }
 
     const [currentPlayerId = null] = Object.keys(players)
 
     return {
-      userPlayerId,
+      sessionOwnerPlayerId,
       table,
       currentPlayerId,
       ...overrides,

--- a/src/game/services/Factory/index.ts
+++ b/src/game/services/Factory/index.ts
@@ -31,11 +31,21 @@ export class Factory {
     }
   }
 
-  static buildGame(overrides: Partial<IGame> = {}): IGame {
+  static buildGame(
+    overrides: Partial<IGame> = {},
+    userPlayerId = uuid()
+  ): IGame {
     const table = Factory.buildTable(overrides?.table)
-    const [currentPlayerId = null] = Object.keys(table.players)
+    const { players } = table
+
+    if (Object.keys(players).length === 0) {
+      players[userPlayerId] = this.buildPlayer({ id: userPlayerId })
+    }
+
+    const [currentPlayerId = null] = Object.keys(players)
 
     return {
+      userPlayerId,
       table,
       currentPlayerId,
       ...overrides,

--- a/src/game/services/Lookup/index.test.ts
+++ b/src/game/services/Lookup/index.test.ts
@@ -4,7 +4,7 @@ import { updatePlayer } from '../../reducers/update-player'
 import { GameStateCorruptError } from '../Rules/errors'
 import { stubGame } from '../../../test-utils/stubs/game'
 
-import { Lookup } from '.'
+import { lookup } from '.'
 
 describe('Lookup', () => {
   describe('getCardFromHand', () => {
@@ -19,14 +19,14 @@ describe('Lookup', () => {
     })
 
     test('returns card from hand', () => {
-      const card = Lookup.getCardFromHand(game, player1Id, 0)
+      const card = lookup.getCardFromHand(game, player1Id, 0)
 
       expect(card).toBe(carrot)
     })
 
     test('throws an error when specified card is not in hand', () => {
       expect(() => {
-        Lookup.getCardFromHand(
+        lookup.getCardFromHand(
           game,
           player1Id,
           game.table.players[player1Id].hand.length
@@ -40,7 +40,7 @@ describe('Lookup', () => {
       })
 
       expect(() => {
-        Lookup.getCardFromHand(game, player1Id, 0)
+        lookup.getCardFromHand(game, player1Id, 0)
       }).toThrow(GameStateCorruptError)
     })
   })

--- a/src/game/services/Lookup/index.test.ts
+++ b/src/game/services/Lookup/index.test.ts
@@ -1,8 +1,9 @@
 import { carrot } from '../../cards'
 import { IGame, IPlayer } from '../../types'
 import { updatePlayer } from '../../reducers/update-player'
-import { GameStateCorruptError } from '../Rules/errors'
+import { GameStateCorruptError, InvalidIdError } from '../Rules/errors'
 import { stubGame } from '../../../test-utils/stubs/game'
+import { isPlayer } from '../../types/guards'
 
 import { lookup } from '.'
 
@@ -54,6 +55,20 @@ describe('Lookup', () => {
 
       expect(opponentPlayerIds).toHaveLength(playerIds.length - 1)
       expect(opponentPlayerIds).not.toContain(game.currentPlayerId)
+    })
+  })
+
+  describe('getPlayer', () => {
+    test('retrieves player', () => {
+      const player = lookup.getPlayer(game, game.userPlayerId)
+
+      expect(isPlayer(player)).toEqual(true)
+    })
+
+    test('throws an error when unavailable player is requested', () => {
+      expect(() => {
+        lookup.getPlayer(game, '')
+      }).toThrow(InvalidIdError)
     })
   })
 })

--- a/src/game/services/Lookup/index.test.ts
+++ b/src/game/services/Lookup/index.test.ts
@@ -6,20 +6,22 @@ import { stubGame } from '../../../test-utils/stubs/game'
 
 import { lookup } from '.'
 
+const game = stubGame()
+
 describe('Lookup', () => {
   describe('getCardFromHand', () => {
-    let game: IGame
+    let mutatedGame: IGame
     let player1Id: IPlayer['id']
 
     beforeEach(() => {
-      game = stubGame()
-      player1Id = Object.keys(game.table.players)[0]
+      mutatedGame = stubGame()
+      player1Id = Object.keys(mutatedGame.table.players)[0]
 
-      game.table.players[player1Id].hand[0] = carrot.id
+      mutatedGame.table.players[player1Id].hand[0] = carrot.id
     })
 
     test('returns card from hand', () => {
-      const card = lookup.getCardFromHand(game, player1Id, 0)
+      const card = lookup.getCardFromHand(mutatedGame, player1Id, 0)
 
       expect(card).toBe(carrot)
     })
@@ -27,21 +29,30 @@ describe('Lookup', () => {
     test('throws an error when specified card is not in hand', () => {
       expect(() => {
         lookup.getCardFromHand(
-          game,
+          mutatedGame,
           player1Id,
-          game.table.players[player1Id].hand.length
+          mutatedGame.table.players[player1Id].hand.length
         )
       }).toThrow()
     })
 
     test('throws an error when specified card is not valid', () => {
-      game = updatePlayer(game, player1Id, {
+      mutatedGame = updatePlayer(mutatedGame, player1Id, {
         hand: ['some-card-that-does-not-exist'],
       })
 
       expect(() => {
-        lookup.getCardFromHand(game, player1Id, 0)
+        lookup.getCardFromHand(mutatedGame, player1Id, 0)
       }).toThrow(GameStateCorruptError)
+    })
+  })
+
+  describe('getOpponentPlayerIds', () => {
+    test('returns opponent player IDs', () => {
+      const opponentPlayerIds = lookup.getOpponentPlayerIds(game)
+
+      expect(opponentPlayerIds).toHaveLength(1)
+      expect(opponentPlayerIds).not.toContain(game.currentPlayerId)
     })
   })
 })

--- a/src/game/services/Lookup/index.test.ts
+++ b/src/game/services/Lookup/index.test.ts
@@ -60,7 +60,7 @@ describe('Lookup', () => {
 
   describe('getPlayer', () => {
     test('retrieves player', () => {
-      const player = lookup.getPlayer(game, game.userPlayerId)
+      const player = lookup.getPlayer(game, game.sessionOwnerPlayerId)
 
       expect(isPlayer(player)).toEqual(true)
     })

--- a/src/game/services/Lookup/index.test.ts
+++ b/src/game/services/Lookup/index.test.ts
@@ -50,8 +50,9 @@ describe('Lookup', () => {
   describe('getOpponentPlayerIds', () => {
     test('returns opponent player IDs', () => {
       const opponentPlayerIds = lookup.getOpponentPlayerIds(game)
+      const playerIds = Object.keys(game.table.players)
 
-      expect(opponentPlayerIds).toHaveLength(1)
+      expect(opponentPlayerIds).toHaveLength(playerIds.length - 1)
       expect(opponentPlayerIds).not.toContain(game.currentPlayerId)
     })
   })

--- a/src/game/services/Lookup/index.ts
+++ b/src/game/services/Lookup/index.ts
@@ -4,11 +4,11 @@ import { ICard, IGame, IPlayer } from '../../types'
 import { GameStateCorruptError } from '../Rules/errors'
 
 export class Lookup {
-  static getCardFromHand(
+  getCardFromHand = (
     game: IGame,
     playerId: IPlayer['id'],
     cardIdx: number
-  ): ICard {
+  ): ICard => {
     const { hand } = game.table.players[playerId]
     const cardId = hand[cardIdx]
 
@@ -29,3 +29,5 @@ export class Lookup {
     return card
   }
 }
+
+export const lookup = new Lookup()

--- a/src/game/services/Lookup/index.ts
+++ b/src/game/services/Lookup/index.ts
@@ -28,6 +28,19 @@ export class Lookup {
 
     return card
   }
+
+  /**
+   * Returns all the IDs for players that are not the current user's.
+   */
+  getOpponentPlayerIds = (game: IGame) => {
+    const playerIds = Object.keys(game.table.players)
+
+    const nonUserPlayers = playerIds.filter(
+      playerId => playerId !== game.userPlayerId
+    )
+
+    return nonUserPlayers
+  }
 }
 
 export const lookup = new Lookup()

--- a/src/game/services/Lookup/index.ts
+++ b/src/game/services/Lookup/index.ts
@@ -1,7 +1,7 @@
 import * as cards from '../../cards'
 import { isCardId } from '../../types/guards'
 import { ICard, IGame, IPlayer } from '../../types'
-import { GameStateCorruptError } from '../Rules/errors'
+import { GameStateCorruptError, InvalidIdError } from '../Rules/errors'
 
 export class Lookup {
   getCardFromHand = (
@@ -40,6 +40,18 @@ export class Lookup {
     )
 
     return nonUserPlayers
+  }
+
+  getPlayer = (game: IGame, playerId: IPlayer['id']) => {
+    const player = game.table.players[playerId]
+
+    if (!player) {
+      throw new InvalidIdError(
+        `playerId ${playerId} does not correspond to any players in the game.`
+      )
+    }
+
+    return player
   }
 }
 

--- a/src/game/services/Lookup/index.ts
+++ b/src/game/services/Lookup/index.ts
@@ -35,11 +35,11 @@ export class Lookup {
   getOpponentPlayerIds = (game: IGame) => {
     const playerIds = Object.keys(game.table.players)
 
-    const nonUserPlayers = playerIds.filter(
-      playerId => playerId !== game.userPlayerId
+    const opponentPlayerIds = playerIds.filter(
+      playerId => playerId !== game.sessionOwnerPlayerId
     )
 
-    return nonUserPlayers
+    return opponentPlayerIds
   }
 
   getPlayer = (game: IGame, playerId: IPlayer['id']) => {

--- a/src/game/services/Rules/errors.ts
+++ b/src/game/services/Rules/errors.ts
@@ -35,6 +35,13 @@ export class InvalidCardError extends Error {
   }
 }
 
+export class InvalidIdError extends Error {
+  constructor(message: string) {
+    super(...arguments)
+    this.message = `[InvalidIdError] ${message}`
+  }
+}
+
 export class PlayerAbortError extends Error {
   constructor() {
     super(...arguments)

--- a/src/game/services/Rules/index.ts
+++ b/src/game/services/Rules/index.ts
@@ -9,7 +9,7 @@ import { payFromPlayerToCommunity } from '../../reducers/pay-from-player-to-comm
 import { updateGame } from '../../reducers/update-game'
 import { incrementPlayer } from '../../reducers/increment-player'
 import { RandomNumber } from '../../../services/RandomNumber'
-import { Lookup } from '../Lookup'
+import { lookup } from '../Lookup'
 
 import { PlayerOutOfFundsError } from './errors'
 import { InteractionHandlers } from './InteractionHandlers'
@@ -73,7 +73,7 @@ export class Rules {
     playerId: IPlayer['id'],
     cardIdx: number
   ): Promise<IGame> {
-    const card = Lookup.getCardFromHand(game, playerId, cardIdx)
+    const card = lookup.getCardFromHand(game, playerId, cardIdx)
 
     game = await card.onPlayFromHand(
       game,

--- a/src/game/services/Rules/index.ts
+++ b/src/game/services/Rules/index.ts
@@ -15,8 +15,11 @@ import { PlayerOutOfFundsError } from './errors'
 import { InteractionHandlers } from './InteractionHandlers'
 
 export class Rules {
-  static processGameStart(playerSeeds: IPlayerSeed[]): IGame {
-    let game = Factory.buildGame()
+  static processGameStart(
+    playerSeeds: IPlayerSeed[],
+    userPlayerId: string | undefined = playerSeeds[0]?.id
+  ): IGame {
+    let game = Factory.buildGame({}, userPlayerId)
 
     for (const playerSeed of playerSeeds) {
       const player = Factory.buildPlayer({

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -65,8 +65,8 @@ export const isGame = (obj: unknown): obj is IGame => {
     isTable(obj.table) &&
     'currentPlayerId' in obj &&
     (typeof obj.currentPlayerId === 'string' || obj.currentPlayerId === null) &&
-    'userPlayerId' in obj &&
-    typeof obj.userPlayerId === 'string'
+    'sessionOwnerPlayerId' in obj &&
+    typeof obj.sessionOwnerPlayerId === 'string'
   )
 }
 

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -64,7 +64,9 @@ export const isGame = (obj: unknown): obj is IGame => {
     'table' in obj &&
     isTable(obj.table) &&
     'currentPlayerId' in obj &&
-    (typeof obj.currentPlayerId === 'string' || obj.currentPlayerId === null)
+    (typeof obj.currentPlayerId === 'string' || obj.currentPlayerId === null) &&
+    'userPlayerId' in obj &&
+    typeof obj.userPlayerId === 'string'
   )
 }
 

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -153,5 +153,8 @@ export interface IGame {
 
   readonly table: ITable
 
+  /**
+   * The IPlayer['id'] of the player whose turn it is.
+   */
   readonly currentPlayerId: IPlayer['id'] | null
 }

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -147,9 +147,9 @@ export interface ITable {
 
 export interface IGame {
   /**
-   * The IPlayer['id'] of the user who owns the current session.
+   * The IPlayer['id'] associated with the user who owns the current session.
    */
-  readonly userPlayerId: IPlayer['id']
+  readonly sessionOwnerPlayerId: IPlayer['id']
 
   readonly table: ITable
 

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -146,6 +146,11 @@ export interface ITable {
 }
 
 export interface IGame {
+  /**
+   * The IPlayer['id'] of the user who owns the current session.
+   */
+  readonly userPlayerId: IPlayer['id']
+
   readonly table: ITable
 
   readonly currentPlayerId: IPlayer['id'] | null

--- a/src/test-utils/stubs/game.ts
+++ b/src/test-utils/stubs/game.ts
@@ -4,5 +4,9 @@ import { IGame } from '../../game/types'
 import { stubTable } from './table'
 
 export const stubGame = (overrides: Partial<IGame> = {}): IGame => {
-  return Factory.buildGame({ table: stubTable(overrides?.table), ...overrides })
+  const table = stubTable(overrides?.table)
+  return Factory.buildGame(
+    { table: table, ...overrides },
+    Object.keys(table.players)[0]
+  )
 }

--- a/src/test-utils/stubs/game.ts
+++ b/src/test-utils/stubs/game.ts
@@ -6,7 +6,7 @@ import { stubTable } from './table'
 export const stubGame = (overrides: Partial<IGame> = {}): IGame => {
   const table = stubTable(overrides?.table)
   return Factory.buildGame(
-    { table: table, ...overrides },
+    { table, ...overrides },
     Object.keys(table.players)[0]
   )
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "jest-setup.ts"]
 }


### PR DESCRIPTION
### What this PR does

This PR is mostly unexciting boilerplate that sets up for more complex rendering logic to follow. Specifically, it scaffolds the following high-level components:

- `Deck`
- `DiscardPile`
- `Field`
- `Game`
- `Hand`
- `Table`

Currently these components don't do much more than render other components. For placeholder logic, they print `JSON.stringify`-ed representations of the data they are concerned with.

### How this change can be validated

Open the new Storybook stories and ensure nothing breaks.

### Additional information

![Screenshot of Storybook for Game component](https://github.com/jeremyckahn/farmhand-shuffle/assets/366330/393488ea-d822-4cbd-88de-4a19d6101146)
