### PR TITLE
feat(ui): Render Field

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 /** @typedef {import('ts-jest').JestConfigWithTsJest} JestConfigWithTsJest */
 
-const modules = ['@mui', '@babel'].join('|')
+const modules = ['@mui', '@babel', '@react-hook'].join('|')
 
 /** @type {JestConfigWithTsJest} */
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fontsource/roboto": "^5.0.8",
         "@mui/icons-material": "^5.14.18",
         "@mui/material": "^5.14.18",
+        "@react-hook/window-size": "^3.1.1",
         "lodash.clamp": "^4.0.3",
         "lodash.clonedeep": "^4.5.0",
         "lodash.shuffle": "^4.2.0",
@@ -6448,6 +6449,57 @@
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@react-hook/debounce": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-hook/debounce/-/debounce-3.0.0.tgz",
+      "integrity": "sha512-ir/kPrSfAzY12Gre0sOHkZ2rkEmM4fS5M5zFxCi4BnCeXh2nvx9Ujd+U4IGpKCuPA+EQD0pg1eK2NGLvfWejag==",
+      "dependencies": {
+        "@react-hook/latest": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/event": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@react-hook/event/-/event-1.2.6.tgz",
+      "integrity": "sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q==",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/latest": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
+      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/throttle": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-hook/throttle/-/throttle-2.2.0.tgz",
+      "integrity": "sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg==",
+      "dependencies": {
+        "@react-hook/latest": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/window-size": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/window-size/-/window-size-3.1.1.tgz",
+      "integrity": "sha512-yWnVS5LKnOUIrEsI44oz3bIIUYqflamPL27n+k/PC//PsX/YeWBky09oPeAoc9As6jSH16Wgo8plI+ECZaHk3g==",
+      "dependencies": {
+        "@react-hook/debounce": "^3.0.0",
+        "@react-hook/event": "^1.2.1",
+        "@react-hook/throttle": "^2.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@fontsource/roboto": "^5.0.8",
     "@mui/icons-material": "^5.14.18",
     "@mui/material": "^5.14.18",
+    "@react-hook/window-size": "^3.1.1",
     "lodash.clamp": "^4.0.3",
     "lodash.clonedeep": "^4.5.0",
     "lodash.shuffle": "^4.2.0",

--- a/src/app/components/Card/Card.stories.ts
+++ b/src/app/components/Card/Card.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { carrot, water } from '../../../game/cards'
+import { carrot, pumpkin, water } from '../../../game/cards'
+import { CardSize } from '../../types'
 
 import { Card } from './Card'
 
@@ -26,5 +27,25 @@ export const CropCard: Story = {
 export const WaterCard: Story = {
   args: {
     card: water,
+  },
+}
+
+export const SmallCard: Story = {
+  args: {
+    card: pumpkin,
+    size: CardSize.SMALL,
+  },
+}
+
+export const MediumCard: Story = {
+  args: {
+    card: pumpkin,
+    size: CardSize.MEDIUM,
+  },
+}
+export const LargeCard: Story = {
+  args: {
+    card: pumpkin,
+    size: CardSize.LARGE,
   },
 }

--- a/src/app/components/Card/Card.stories.ts
+++ b/src/app/components/Card/Card.stories.ts
@@ -23,16 +23,6 @@ export const CropCard: Story = {
   },
 }
 
-export const PlayedCropCard: Story = {
-  args: {
-    card: carrot,
-    playedCrop: {
-      id: carrot.id,
-      waterCards: 1,
-    },
-  },
-}
-
 export const WaterCard: Story = {
   args: {
     card: water,

--- a/src/app/components/Card/Card.tsx
+++ b/src/app/components/Card/Card.tsx
@@ -8,13 +8,15 @@ import {
   isWaterCard,
 } from '../../../game/types'
 import { isCrop } from '../../../game/types/guards'
+import { CardSize } from '../../types'
 
 import { CardCropText } from './CardCropText'
 import { CardTemplate } from './CardTemplate'
 
 export interface BaseCardProps extends PaperProps {
   card: ICard
-  size?: number
+  size?: CardSize
+  imageScale?: number
 }
 
 export interface CropCardProps extends BaseCardProps {

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -12,6 +12,8 @@ import { CardSize } from '../../types'
 
 import { CardProps } from './Card'
 
+export const cardClassName = 'Card'
+
 export const CardTemplate = ({
   card,
   imageScale = 0.75,
@@ -30,6 +32,7 @@ export const CardTemplate = ({
 
   return (
     <Paper
+      className={cardClassName}
       sx={[
         {
           width: CARD_DIMENSIONS[size].width,

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -5,16 +5,17 @@ import useTheme from '@mui/material/styles/useTheme'
 import Typography from '@mui/material/Typography'
 import { darken, lighten } from '@mui/material/styles'
 
-import { CARD_HEIGHT, CARD_WIDTH } from '../../config/dimensions'
+import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { cards, isCardImageKey, ui } from '../../img'
-
 import { Image } from '../Image'
+import { CardSize } from '../../types'
 
 import { CardProps } from './Card'
 
 export const CardTemplate = ({
   card,
-  size = 0.75,
+  imageScale = 0.75,
+  size = CardSize.MEDIUM,
   sx = [],
   children,
   ...props
@@ -31,8 +32,8 @@ export const CardTemplate = ({
     <Paper
       sx={[
         {
-          width: CARD_WIDTH,
-          height: CARD_HEIGHT,
+          width: CARD_DIMENSIONS[size].width,
+          height: CARD_DIMENSIONS[size].height,
           background:
             theme.palette.mode === 'light'
               ? darken(theme.palette.background.paper, 0.05)
@@ -71,7 +72,7 @@ export const CardTemplate = ({
           src={imageSrc}
           alt={card.name}
           sx={{
-            height: `${100 * size}%`,
+            height: `${100 * imageScale}%`,
             p: 0,
             m: 'auto',
             imageRendering: 'pixelated',

--- a/src/app/components/Field/Field.stories.ts
+++ b/src/app/components/Field/Field.stories.ts
@@ -27,9 +27,9 @@ const gameWithFieldWithThreePlayedCrops = updateField(
   baseGame.sessionOwnerPlayerId,
   {
     crops: [
-      Factory.buildPlayedCrop(carrot),
-      Factory.buildPlayedCrop(pumpkin),
-      Factory.buildPlayedCrop(pumpkin),
+      { ...Factory.buildPlayedCrop(carrot), waterCards: 1 },
+      { ...Factory.buildPlayedCrop(pumpkin), waterCards: 3 },
+      { ...Factory.buildPlayedCrop(pumpkin), waterCards: 12 },
     ],
   }
 )

--- a/src/app/components/Field/Field.stories.ts
+++ b/src/app/components/Field/Field.stories.ts
@@ -20,23 +20,37 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const baseGame = stubGame()
+let game = stubGame()
 
-const gameWithFieldWithThreePlayedCrops = updateField(
-  baseGame,
-  baseGame.sessionOwnerPlayerId,
-  {
-    crops: [
-      { ...Factory.buildPlayedCrop(carrot), waterCards: 1 },
-      { ...Factory.buildPlayedCrop(pumpkin), waterCards: 3 },
-      { ...Factory.buildPlayedCrop(pumpkin), waterCards: 12 },
-    ],
-  }
-)
+const selfPlayerId = game.sessionOwnerPlayerId
+const opponentPlayerId = Object.keys(game.table.players)[1]
+
+game = updateField(game, selfPlayerId, {
+  crops: [
+    { ...Factory.buildPlayedCrop(carrot), waterCards: 1 },
+    { ...Factory.buildPlayedCrop(pumpkin), waterCards: 3 },
+    { ...Factory.buildPlayedCrop(pumpkin), waterCards: 12 },
+  ],
+})
+
+game = updateField(game, opponentPlayerId, {
+  crops: [
+    { ...Factory.buildPlayedCrop(carrot), waterCards: 1 },
+    { ...Factory.buildPlayedCrop(pumpkin), waterCards: 3 },
+    { ...Factory.buildPlayedCrop(pumpkin), waterCards: 12 },
+  ],
+})
 
 export const SelfField: Story = {
   args: {
-    playerId: gameWithFieldWithThreePlayedCrops.sessionOwnerPlayerId,
-    game: gameWithFieldWithThreePlayedCrops,
+    playerId: game.sessionOwnerPlayerId,
+    game: game,
+  },
+}
+
+export const OpponentField: Story = {
+  args: {
+    playerId: opponentPlayerId,
+    game: game,
   },
 }

--- a/src/app/components/Field/Field.stories.ts
+++ b/src/app/components/Field/Field.stories.ts
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { stubGame } from '../../../test-utils/stubs/game'
+import { updateField } from '../../../game/reducers/update-field'
+import { carrot, pumpkin } from '../../../game/cards'
+import { Factory } from '../../../game/services/Factory'
 
 import { Field } from './Field'
 
@@ -17,11 +20,23 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const game = stubGame()
+const baseGame = stubGame()
+
+const gameWithFieldWithThreePlayedCrops = updateField(
+  baseGame,
+  baseGame.sessionOwnerPlayerId,
+  {
+    crops: [
+      Factory.buildPlayedCrop(carrot),
+      Factory.buildPlayedCrop(pumpkin),
+      Factory.buildPlayedCrop(pumpkin),
+    ],
+  }
+)
 
 export const SelfField: Story = {
   args: {
-    playerId: game.sessionOwnerPlayerId,
-    game,
+    playerId: gameWithFieldWithThreePlayedCrops.sessionOwnerPlayerId,
+    game: gameWithFieldWithThreePlayedCrops,
   },
 }

--- a/src/app/components/Field/Field.test.tsx
+++ b/src/app/components/Field/Field.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { Factory } from '../../../game/services/Factory'
+import { updateField } from '../../../game/reducers/update-field'
+import { stubGame } from '../../../test-utils/stubs/game'
+import { carrot, pumpkin } from '../../../game/cards'
+import * as cards from '../../../game/cards'
+import { isCardId } from '../../../game/types/guards'
+import { playedCropWrapperClassName } from '../PlayedCrop'
+import { cardClassName } from '../Card/CardTemplate'
+
+import { Field, FieldProps, rotationTransform } from '.'
+
+let gameStub = stubGame()
+const opponentPlayerId = Object.keys(gameStub.table.players)[1]
+
+const fieldCrop1 = carrot
+const fieldCrop2 = pumpkin
+
+const cropsStub = [
+  { ...Factory.buildPlayedCrop(fieldCrop1), waterCards: 1 },
+  { ...Factory.buildPlayedCrop(fieldCrop2), waterCards: 3 },
+]
+
+gameStub = updateField(gameStub, gameStub.sessionOwnerPlayerId, {
+  crops: cropsStub,
+})
+
+gameStub = updateField(gameStub, opponentPlayerId, {
+  crops: cropsStub,
+})
+
+const StubField = (overrides: Partial<FieldProps>) => {
+  return (
+    <Field
+      game={gameStub}
+      playerId={gameStub.sessionOwnerPlayerId}
+      {...overrides}
+    />
+  )
+}
+
+describe('Field', () => {
+  test('renders crop cards for self', () => {
+    render(<StubField />)
+
+    for (const crop of cropsStub) {
+      if (!isCardId(crop.id)) {
+        throw new Error()
+      }
+
+      const card = screen
+        .getByText(cards[crop.id].name)
+        .closest(`.${cardClassName}`)
+
+      const { transform } = getComputedStyle(card!)
+      expect(transform).toMatchSnapshot()
+    }
+  })
+
+  test('renders crop cards for opponent upside-down', async () => {
+    render(<StubField playerId={opponentPlayerId} />)
+
+    for (const crop of cropsStub) {
+      if (!isCardId(crop.id)) {
+        throw new Error()
+      }
+
+      const card = screen
+        .getByText(cards[crop.id].name)
+        .closest(`.${playedCropWrapperClassName}`)
+
+      const { transform } = getComputedStyle(card!)
+      expect(transform).toMatchSnapshot()
+      expect(transform).toContain(rotationTransform)
+    }
+  })
+
+  test('clicking a card selects it', async () => {
+    render(<StubField />)
+
+    const playedCrop1 = screen
+      .getByText(fieldCrop1.name)
+      .closest(`.${cardClassName}`)
+
+    const playedCrop1Wrapper = screen
+      .getByText(fieldCrop1.name)
+      .closest(`.${playedCropWrapperClassName}`)
+
+    await userEvent.click(playedCrop1!)
+
+    const { transform: playedCrop1Transform } = getComputedStyle(
+      playedCrop1Wrapper!
+    )
+
+    expect(playedCrop1Transform).toMatchSnapshot()
+
+    for (const crop of cropsStub.slice(1)) {
+      if (!isCardId(crop.id)) {
+        throw new Error()
+      }
+
+      const cardWrapper = screen
+        .getByText(cards[crop.id].name)
+        .closest(`.${playedCropWrapperClassName}`)
+
+      const { transform } = getComputedStyle(cardWrapper!)
+      expect(transform).toMatchSnapshot()
+    }
+  })
+
+  test("clicking an opponent's card selects it", async () => {
+    render(<StubField playerId={opponentPlayerId} />)
+
+    const playedCrop1 = screen
+      .getByText(fieldCrop1.name)
+      .closest(`.${cardClassName}`)
+
+    const playedCrop1Wrapper = screen
+      .getByText(fieldCrop1.name)
+      .closest(`.${playedCropWrapperClassName}`)
+
+    await userEvent.click(playedCrop1!)
+
+    const { transform } = getComputedStyle(playedCrop1Wrapper!)
+
+    expect(transform).toMatchSnapshot()
+    expect(transform).not.toContain(rotationTransform)
+  })
+
+  test('losing focus resets the card selection', async () => {
+    render(<StubField />)
+
+    const playedCrop1 = screen
+      .getByText(fieldCrop1.name)
+      .closest(`.${cardClassName}`)
+
+    const playedCrop1Wrapper = screen
+      .getByText(fieldCrop1.name)
+      .closest(`.${playedCropWrapperClassName}`)
+
+    await userEvent.click(playedCrop1!)
+
+    await waitFor(() => {
+      ;(document.activeElement as HTMLElement).blur()
+    })
+
+    const { transform } = getComputedStyle(playedCrop1Wrapper!)
+    expect(transform).toMatchSnapshot()
+  })
+
+  test('supports tab navigation', async () => {
+    render(<StubField />)
+
+    const card1 = screen.getByText(fieldCrop1.name).closest(`.${cardClassName}`)
+    const cardWrapper1 = screen
+      .getByText(fieldCrop1.name)
+      .closest(`.${playedCropWrapperClassName}`)
+
+    const cardWrapper2 = screen
+      .getByText(fieldCrop2.name)
+      .closest(`.${playedCropWrapperClassName}`)
+
+    await userEvent.click(card1!)
+
+    await waitFor(() => {
+      userEvent.keyboard('{Tab}')
+    })
+
+    const { transform: card1Transform } = getComputedStyle(cardWrapper1!)
+    const { transform: card2Transform } = getComputedStyle(cardWrapper2!)
+
+    expect(card1Transform).toMatchSnapshot()
+    expect(card2Transform).toMatchSnapshot()
+  })
+
+  test('focus can be escaped', async () => {
+    render(<StubField />)
+
+    const card1 = screen.getByText(fieldCrop1.name).closest(`.${cardClassName}`)
+    const cardWrapper1 = screen
+      .getByText(fieldCrop1.name)
+      .closest(`.${playedCropWrapperClassName}`)
+
+    await userEvent.click(card1!)
+
+    await waitFor(() => {
+      userEvent.keyboard('{Escape}')
+    })
+
+    const { transform: card1Transform } = getComputedStyle(cardWrapper1!)
+    expect(card1Transform).toMatchSnapshot()
+    expect(document.activeElement).toBe(document.body)
+  })
+})

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -4,10 +4,10 @@ import Box, { BoxProps } from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
 import useTheme from '@mui/material/styles/useTheme'
 
+import { PlayedCrop } from '../PlayedCrop'
 import * as cards from '../../../game/cards'
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
-import { Card } from '../Card'
 import { isCardId } from '../../../game/types/guards'
 import { UnimplementedError } from '../../../game/services/Rules/errors'
 import { SELECTED_CARD_ELEVATION } from '../../../game/config'
@@ -98,7 +98,9 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
       onBlur={handleBlur}
     >
       <Grid container spacing={2}>
-        {player.field.crops.map(({ id, waterCards }, idx) => {
+        {player.field.crops.map((playedCrop, idx) => {
+          const { id, waterCards } = playedCrop
+
           if (!isCardId(id)) {
             throw new UnimplementedError(`${id} is not a card`)
           }
@@ -108,8 +110,9 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
 
           return (
             <Grid key={`${idx}_${id}_${waterCards}`} item xs>
-              <Card
+              <PlayedCrop
                 card={card}
+                playedCrop={playedCrop}
                 onFocus={evt => handleCardFocus(evt, idx)}
                 tabIndex={0}
                 elevation={isSelected ? SELECTED_CARD_ELEVATION : undefined}

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -117,10 +117,7 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
                 tabIndex={0}
                 elevation={isSelected ? SELECTED_CARD_ELEVATION : undefined}
                 sx={{
-                  transition: theme.transitions.create([
-                    'transition',
-                    'transform',
-                  ]),
+                  transition: theme.transitions.create(['transform']),
                   ...(isSelected && {
                     transform: selectedCardTransform,
                     zIndex: 20,

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -122,12 +122,16 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
           return (
             <Grid key={`${idx}_${id}_${waterCards}`} item xs>
               <PlayedCrop
-                card={card}
-                playedCrop={playedCrop}
+                cropCardProps={{
+                  card,
+                  playedCrop,
+                  tabIndex: 0,
+                  ...(isSelected && {
+                    elevation: SELECTED_CARD_ELEVATION,
+                  }),
+                }}
                 isInBackground={isInBackground}
                 onFocus={evt => handleCardFocus(evt, idx)}
-                tabIndex={0}
-                elevation={isSelected ? SELECTED_CARD_ELEVATION : undefined}
                 sx={{
                   position: 'relative',
                   transition: theme.transitions.create(['transform']),

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -13,7 +13,7 @@ import { UnimplementedError } from '../../../game/services/Rules/errors'
 import { SELECTED_CARD_ELEVATION } from '../../../game/config'
 
 const deselectedIdx = -1
-const selectedCardYOffset = -75
+const selectedCardYOffset = -25
 
 export interface FieldProps extends BoxProps {
   game: IGame
@@ -117,6 +117,7 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
                 tabIndex={0}
                 elevation={isSelected ? SELECTED_CARD_ELEVATION : undefined}
                 sx={{
+                  position: 'relative',
                   transition: theme.transitions.create(['transform']),
                   ...(isSelected && {
                     transform: selectedCardTransform,

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -1,6 +1,7 @@
+import { useRef, useState } from 'react'
 import Box, { BoxProps } from '@mui/material/Box'
-
-import { Grid } from '@mui/material'
+import Grid from '@mui/material/Grid'
+import useTheme from '@mui/material/styles/useTheme'
 
 import * as cards from '../../../game/cards'
 import { lookup } from '../../../game/services/Lookup'
@@ -8,6 +9,8 @@ import { IGame, IPlayer } from '../../../game/types'
 import { Card } from '../Card'
 import { isCardId } from '../../../game/types/guards'
 import { UnimplementedError } from '../../../game/services/Rules/errors'
+
+const deselectedIdx = -1
 
 export interface FieldProps extends BoxProps {
   game: IGame
@@ -17,8 +20,47 @@ export interface FieldProps extends BoxProps {
 export const Field = ({ playerId, game, ...rest }: FieldProps) => {
   const player = lookup.getPlayer(game, playerId)
 
+  const containerRef = useRef<HTMLDivElement>()
+  const theme = useTheme()
+  const [selectedCardIdx, setSelectedCardIdx] = useState(deselectedIdx)
+
+  const resetSelectedCard = () => {
+    setSelectedCardIdx(deselectedIdx)
+
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur()
+    }
+  }
+
+  const handleCardFocus = (cardIdx: number) => {
+    setSelectedCardIdx(cardIdx)
+  }
+
+  const handleKeyDown = (evt: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (evt.key) {
+      case 'Escape':
+        resetSelectedCard()
+        break
+    }
+  }
+
+  const handleBlur = (evt: React.FocusEvent<HTMLDivElement, Element>) => {
+    if (
+      containerRef.current &&
+      !containerRef.current.contains(evt.relatedTarget)
+    ) {
+      resetSelectedCard()
+    }
+  }
+
   return (
-    <Box {...rest} data-testid={`field_${playerId}`}>
+    <Box
+      {...rest}
+      data-testid={`field_${playerId}`}
+      ref={containerRef}
+      onKeyDown={handleKeyDown}
+      onBlur={handleBlur}
+    >
       <Grid container spacing={2}>
         {player.field.crops.map(({ id, waterCards }, idx) => {
           if (!isCardId(id)) {
@@ -26,10 +68,25 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
           }
 
           const card = cards[id]
+          const isSelected = selectedCardIdx === idx
 
           return (
             <Grid key={`${idx}_${id}_${waterCards}`} item xs>
-              <Card card={card} />
+              <Card
+                card={card}
+                onFocus={() => handleCardFocus(idx)}
+                tabIndex={0}
+                sx={{
+                  transition: theme.transitions.create([
+                    'transition',
+                    'transform',
+                  ]),
+                  ...(isSelected && {
+                    // FIXME: Use a dynamically centered transform here
+                    transform: `translateX(200px) translateY(200px)`,
+                  }),
+                }}
+              />
             </Grid>
           )
         })}

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -1,7 +1,13 @@
 import Box, { BoxProps } from '@mui/material/Box'
 
+import { Grid } from '@mui/material'
+
+import * as cards from '../../../game/cards'
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
+import { Card } from '../Card'
+import { isCardId } from '../../../game/types/guards'
+import { UnimplementedError } from '../../../game/services/Rules/errors'
 
 export interface FieldProps extends BoxProps {
   game: IGame
@@ -13,7 +19,21 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
 
   return (
     <Box {...rest} data-testid={`field_${playerId}`}>
-      {JSON.stringify(player, null, 2)}
+      <Grid container spacing={2}>
+        {player.field.crops.map(({ id, waterCards }, idx) => {
+          if (!isCardId(id)) {
+            throw new UnimplementedError(`${id} is not a card`)
+          }
+
+          const card = cards[id]
+
+          return (
+            <Grid key={`${idx}_${id}_${waterCards}`} item xs>
+              <Card card={card} />
+            </Grid>
+          )
+        })}
+      </Grid>
     </Box>
   )
 }

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -13,7 +13,7 @@ import { UnimplementedError } from '../../../game/services/Rules/errors'
 import { SELECTED_CARD_ELEVATION } from '../../../game/config'
 
 const deselectedIdx = -1
-const selectedCardYOffset = -50
+const selectedCardYOffset = -75
 
 export interface FieldProps extends BoxProps {
   game: IGame
@@ -66,7 +66,9 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
       (boundingClientRect.top + boundingClientRect.height / 2) +
       selectedCardYOffset
 
-    setSelectedCardTransform(`translateX(${xDelta}px) translateY(${yDelta}px)`)
+    setSelectedCardTransform(
+      `translateX(${xDelta}px) translateY(${yDelta}px) scale(1.25)`
+    )
     setSelectedCardIdx(cardIdx)
   }
 

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useWindowSize } from '@react-hook/window-size'
 import Box, { BoxProps } from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
@@ -40,6 +40,18 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
     }
   }
 
+  useEffect(() => {
+    const handleWindowResize = () => {
+      resetSelectedCard()
+    }
+
+    window.addEventListener('resize', handleWindowResize)
+
+    return () => {
+      window.removeEventListener('resize', handleWindowResize)
+    }
+  }, [])
+
   const handleCardFocus = (
     evt: React.FocusEvent<HTMLDivElement, Element>,
     cardIdx: number
@@ -54,7 +66,6 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
       (boundingClientRect.top + boundingClientRect.height / 2) +
       selectedCardYOffset
 
-    // FIXME: Update transform when window size changes
     setSelectedCardTransform(`translateX(${xDelta}px) translateY(${yDelta}px)`)
     setSelectedCardIdx(cardIdx)
   }

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -107,12 +107,15 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
 
           const card = cards[id]
           const isSelected = selectedCardIdx === idx
+          const isInBackground =
+            selectedCardIdx !== deselectedIdx && !isSelected
 
           return (
             <Grid key={`${idx}_${id}_${waterCards}`} item xs>
               <PlayedCrop
                 card={card}
                 playedCrop={playedCrop}
+                isInBackground={isInBackground}
                 onFocus={evt => handleCardFocus(evt, idx)}
                 tabIndex={0}
                 elevation={isSelected ? SELECTED_CARD_ELEVATION : undefined}

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -22,6 +22,7 @@ export interface FieldProps extends BoxProps {
 
 export const Field = ({ playerId, game, ...rest }: FieldProps) => {
   const player = lookup.getPlayer(game, playerId)
+  const isSessionOwnerPlayer = playerId === game.sessionOwnerPlayerId
 
   const containerRef = useRef<HTMLDivElement>()
   const theme = useTheme()
@@ -64,7 +65,7 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
     const yDelta =
       centerY -
       (boundingClientRect.top + boundingClientRect.height / 2) +
-      selectedCardYOffset
+      (isSessionOwnerPlayer ? selectedCardYOffset : -selectedCardYOffset)
 
     setSelectedCardTransform(
       `translateX(${xDelta}px) translateY(${yDelta}px) scale(1.25)`
@@ -89,6 +90,10 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
     }
   }
 
+  const crops = isSessionOwnerPlayer
+    ? player.field.crops
+    : [...player.field.crops].reverse()
+
   return (
     <Box
       {...rest}
@@ -97,8 +102,12 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
       onKeyDown={handleKeyDown}
       onBlur={handleBlur}
     >
-      <Grid container spacing={2}>
-        {player.field.crops.map((playedCrop, idx) => {
+      <Grid
+        container
+        spacing={2}
+        alignItems={isSessionOwnerPlayer ? 'flex-start' : 'flex-end'}
+      >
+        {crops.map((playedCrop, idx) => {
           const { id, waterCards } = playedCrop
 
           if (!isCardId(id)) {
@@ -122,6 +131,9 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
                 sx={{
                   position: 'relative',
                   transition: theme.transitions.create(['transform']),
+                  ...(!isSessionOwnerPlayer && {
+                    transform: 'rotate(180deg)',
+                  }),
                   ...(isSelected && {
                     transform: selectedCardTransform,
                     zIndex: 20,

--- a/src/app/components/Field/Field.tsx
+++ b/src/app/components/Field/Field.tsx
@@ -20,6 +20,8 @@ export interface FieldProps extends BoxProps {
   playerId: IPlayer['id']
 }
 
+export const rotationTransform = 'rotate(180deg)'
+
 export const Field = ({ playerId, game, ...rest }: FieldProps) => {
   const player = lookup.getPlayer(game, playerId)
   const isSessionOwnerPlayer = playerId === game.sessionOwnerPlayerId
@@ -136,7 +138,7 @@ export const Field = ({ playerId, game, ...rest }: FieldProps) => {
                   position: 'relative',
                   transition: theme.transitions.create(['transform']),
                   ...(!isSessionOwnerPlayer && {
-                    transform: 'rotate(180deg)',
+                    transform: rotationTransform,
                   }),
                   ...(isSelected && {
                     transform: selectedCardTransform,

--- a/src/app/components/Field/__snapshots__/Field.test.tsx.snap
+++ b/src/app/components/Field/__snapshots__/Field.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Field clicking a card selects it 1`] = `"translateX(0px) translateY(-25px) scale(1.25)"`;
+
+exports[`Field clicking a card selects it 2`] = `""`;
+
+exports[`Field clicking an opponent's card selects it 1`] = `"translateX(0px) translateY(25px) scale(1.25)"`;
+
+exports[`Field focus can be escaped 1`] = `""`;
+
+exports[`Field losing focus resets the card selection 1`] = `""`;
+
+exports[`Field renders crop cards for opponent upside-down 1`] = `"rotate(180deg)"`;
+
+exports[`Field renders crop cards for opponent upside-down 2`] = `"rotate(180deg)"`;
+
+exports[`Field renders crop cards for self 1`] = `""`;
+
+exports[`Field renders crop cards for self 2`] = `""`;
+
+exports[`Field supports tab navigation 1`] = `""`;
+
+exports[`Field supports tab navigation 2`] = `"translateX(0px) translateY(-25px) scale(1.25)"`;

--- a/src/app/components/Hand/Hand.stories.tsx
+++ b/src/app/components/Hand/Hand.stories.tsx
@@ -11,7 +11,8 @@ import { carrot, pumpkin, water } from '../../../game/cards'
 import { updatePlayer } from '../../../game/reducers/update-player'
 import { lookup } from '../../../game/services/Lookup'
 import { stubGame } from '../../../test-utils/stubs/game'
-import { CARD_HEIGHT, CARD_WIDTH } from '../../config/dimensions'
+import { CARD_DIMENSIONS } from '../../config/dimensions'
+import { CardSize } from '../../types'
 
 import { Hand } from './Hand'
 
@@ -46,8 +47,8 @@ const meta = {
       return (
         <Box
           sx={{
-            minHeight: `calc(${CARD_HEIGHT} * 1.35)`,
-            minWidth: `calc(${CARD_WIDTH} * 3)`,
+            minHeight: `calc(${CARD_DIMENSIONS[CardSize.LARGE].height} * 1.35)`,
+            minWidth: `calc(${CARD_DIMENSIONS[CardSize.LARGE].width} * 3)`,
             display: 'flex',
             position: 'relative',
           }}
@@ -114,6 +115,7 @@ export const HandOf3: Story = {
   args: {
     playerId: gameWithHandOf3.sessionOwnerPlayerId,
     game: gameWithHandOf3,
+    cardSize: CardSize.LARGE,
   },
 }
 
@@ -121,5 +123,6 @@ export const HandOf5: Story = {
   args: {
     playerId: gameWithHandOf5.sessionOwnerPlayerId,
     game: gameWithHandOf5,
+    cardSize: CardSize.LARGE,
   },
 }

--- a/src/app/components/Hand/Hand.test.tsx
+++ b/src/app/components/Hand/Hand.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { carrot, pumpkin, water } from '../../../game/cards'
 import { updatePlayer } from '../../../game/reducers/update-player'
 import { stubGame } from '../../../test-utils/stubs/game'
+import { cardClassName } from '../Card/CardTemplate'
 
 import {
   getGapPixelWidth,
@@ -30,7 +31,7 @@ describe('Hand', () => {
     render(<StubHand />)
 
     for (const { name } of handCards) {
-      const card = screen.getByText(name).closest('.MuiPaper-root')
+      const card = screen.getByText(name).closest(`.${cardClassName}`)
 
       const { transform } = getComputedStyle(card!)
       expect(transform).toMatchSnapshot()
@@ -40,14 +41,16 @@ describe('Hand', () => {
   test('clicking a card selects it', async () => {
     render(<StubHand />)
 
-    const card1 = screen.getByText(handCards[0].name).closest('.MuiPaper-root')
+    const card1 = screen
+      .getByText(handCards[0].name)
+      .closest(`.${cardClassName}`)
     await userEvent.click(card1!)
 
     const { transform: card1Transform } = getComputedStyle(card1!)
     expect(card1Transform).toEqual(selectedCardTransform)
 
     for (const { name } of handCards.slice(1)) {
-      const card = screen.getByText(name).closest('.MuiPaper-root')
+      const card = screen.getByText(name).closest(`.${cardClassName}`)
 
       const { transform } = getComputedStyle(card!)
       expect(transform).toMatchSnapshot()
@@ -57,7 +60,9 @@ describe('Hand', () => {
   test('losing focus resets the card selection', async () => {
     render(<StubHand />)
 
-    const card1 = screen.getByText(handCards[0].name).closest('.MuiPaper-root')
+    const card1 = screen
+      .getByText(handCards[0].name)
+      .closest(`.${cardClassName}`)
 
     await userEvent.click(card1!)
 
@@ -72,8 +77,12 @@ describe('Hand', () => {
   test('supports tab navigation', async () => {
     render(<StubHand />)
 
-    const card1 = screen.getByText(handCards[0].name).closest('.MuiPaper-root')
-    const card2 = screen.getByText(handCards[1].name).closest('.MuiPaper-root')
+    const card1 = screen
+      .getByText(handCards[0].name)
+      .closest(`.${cardClassName}`)
+    const card2 = screen
+      .getByText(handCards[1].name)
+      .closest(`.${cardClassName}`)
 
     await userEvent.click(card1!)
 
@@ -91,7 +100,9 @@ describe('Hand', () => {
   test('focus can be escaped', async () => {
     render(<StubHand />)
 
-    const card1 = screen.getByText(handCards[0].name).closest('.MuiPaper-root')
+    const card1 = screen
+      .getByText(handCards[0].name)
+      .closest(`.${cardClassName}`)
 
     await userEvent.click(card1!)
 

--- a/src/app/components/Hand/Hand.tsx
+++ b/src/app/components/Hand/Hand.tsx
@@ -2,15 +2,16 @@ import { useRef, useState } from 'react'
 import Box, { BoxProps } from '@mui/material/Box'
 import useTheme from '@mui/material/styles/useTheme'
 
-import { Card } from '../Card'
 import { mathService } from '../../../services/Math'
 import { lookup } from '../../../game/services/Lookup'
 import { UnimplementedError } from '../../../game/services/Rules/errors'
 import * as cards from '../../../game/cards'
 import { IGame, IPlayer } from '../../../game/types'
 import { isCardId } from '../../../game/types/guards'
-import { CARD_HEIGHT } from '../../config/dimensions'
+import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { SELECTED_CARD_ELEVATION } from '../../../game/config'
+import { CardSize } from '../../types'
+import { Card } from '../Card'
 
 export const selectedCardTransform = `translateX(-50%) translateY(0) rotate(0deg) scale(1) rotateY(0deg)`
 
@@ -38,9 +39,16 @@ export const getGapPixelWidth = (numberOfCards: number) => {
 export interface HandProps extends BoxProps {
   game: IGame
   playerId: IPlayer['id']
+  cardSize?: CardSize
 }
 
-export const Hand = ({ playerId, game, sx = [], ...rest }: HandProps) => {
+export const Hand = ({
+  playerId,
+  game,
+  cardSize = CardSize.LARGE,
+  sx = [],
+  ...rest
+}: HandProps) => {
   const player = lookup.getPlayer(game, playerId)
 
   const containerRef = useRef<HTMLDivElement>()
@@ -86,7 +94,7 @@ export const Hand = ({ playerId, game, sx = [], ...rest }: HandProps) => {
       sx={[
         {
           position: 'relative',
-          minHeight: CARD_HEIGHT,
+          minHeight: CARD_DIMENSIONS[cardSize].height,
         },
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
@@ -115,7 +123,7 @@ export const Hand = ({ playerId, game, sx = [], ...rest }: HandProps) => {
         const translateY =
           selectedCardIdx === deselectedIdx
             ? '0rem'
-            : `calc(${CARD_HEIGHT} / 2)`
+            : `calc(${CARD_DIMENSIONS[cardSize].height} / 2)`
         const rotationDeg = -5
         const scale =
           selectedCardIdx === deselectedIdx
@@ -130,6 +138,7 @@ export const Hand = ({ playerId, game, sx = [], ...rest }: HandProps) => {
           <Card
             key={`${cardId}_${idx}`}
             card={card}
+            size={cardSize}
             elevation={isSelected ? SELECTED_CARD_ELEVATION : undefined}
             sx={{
               transform,

--- a/src/app/components/Hand/Hand.tsx
+++ b/src/app/components/Hand/Hand.tsx
@@ -143,7 +143,7 @@ export const Hand = ({
             sx={{
               transform,
               position: 'absolute',
-              transition: theme.transitions.create(['transition', 'transform']),
+              transition: theme.transitions.create(['transform']),
               cursor: 'pointer',
               ...(isSelected && {
                 zIndex: foregroundCardZIndex,

--- a/src/app/components/Hand/Hand.tsx
+++ b/src/app/components/Hand/Hand.tsx
@@ -10,6 +10,7 @@ import * as cards from '../../../game/cards'
 import { IGame, IPlayer } from '../../../game/types'
 import { isCardId } from '../../../game/types/guards'
 import { CARD_HEIGHT } from '../../config/dimensions'
+import { SELECTED_CARD_ELEVATION } from '../../../game/config'
 
 export const selectedCardTransform = `translateX(-50%) translateY(0) rotate(0deg) scale(1) rotateY(0deg)`
 
@@ -129,6 +130,7 @@ export const Hand = ({ playerId, game, sx = [], ...rest }: HandProps) => {
           <Card
             key={`${cardId}_${idx}`}
             card={card}
+            elevation={isSelected ? SELECTED_CARD_ELEVATION : undefined}
             sx={{
               transform,
               position: 'absolute',

--- a/src/app/components/PlayedCrop/PlayedCrop.stories.ts
+++ b/src/app/components/PlayedCrop/PlayedCrop.stories.ts
@@ -20,6 +20,7 @@ type Story = StoryObj<typeof meta>
 export const PlayedCropCard: Story = {
   args: {
     card: carrot,
+    isInBackground: false,
     playedCrop: {
       id: carrot.id,
       waterCards: 1,

--- a/src/app/components/PlayedCrop/PlayedCrop.stories.ts
+++ b/src/app/components/PlayedCrop/PlayedCrop.stories.ts
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { carrot } from '../../../game/cards'
+
+import { PlayedCrop } from './PlayedCrop'
+
+const meta = {
+  title: 'Farmhand Shuffle/PlayedCrop',
+  component: PlayedCrop,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof PlayedCrop>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const PlayedCropCard: Story = {
+  args: {
+    card: carrot,
+    playedCrop: {
+      id: carrot.id,
+      waterCards: 1,
+    },
+  },
+}

--- a/src/app/components/PlayedCrop/PlayedCrop.stories.ts
+++ b/src/app/components/PlayedCrop/PlayedCrop.stories.ts
@@ -19,11 +19,13 @@ type Story = StoryObj<typeof meta>
 
 export const PlayedCropCard: Story = {
   args: {
-    card: carrot,
-    isInBackground: false,
-    playedCrop: {
-      id: carrot.id,
-      waterCards: 1,
+    cropCardProps: {
+      card: carrot,
+      playedCrop: {
+        id: carrot.id,
+        waterCards: 1,
+      },
     },
+    isInBackground: false,
   },
 }

--- a/src/app/components/PlayedCrop/PlayedCrop.test.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.test.tsx
@@ -36,4 +36,28 @@ describe('PlayedCrop', () => {
       stubWaterCards
     )
   })
+
+  test('foreground water indicators are visible', () => {
+    render(<StubCropCard />)
+
+    const waterIndicators = screen.getAllByAltText('Water card indicator')
+
+    for (const waterIndicator of waterIndicators) {
+      const { opacity } = getComputedStyle(waterIndicator)
+
+      expect(opacity).toEqual('1')
+    }
+  })
+
+  test('background water indicators are not visible', () => {
+    render(<StubCropCard isInBackground={true} />)
+
+    const waterIndicators = screen.getAllByAltText('Water card indicator')
+
+    for (const waterIndicator of waterIndicators) {
+      const { opacity } = getComputedStyle(waterIndicator)
+
+      expect(opacity).toEqual('0')
+    }
+  })
 })

--- a/src/app/components/PlayedCrop/PlayedCrop.test.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.test.tsx
@@ -12,11 +12,11 @@ const stubPlayedCrop: IPlayedCrop = {
   id: stubCard.id,
   waterCards: stubWaterCards,
 }
+const stubCropCardProps = { card: stubCard, playedCrop: stubPlayedCrop }
 
 const StubCropCard = (overrides: Partial<PlayedCropProps> = {}) => (
   <PlayedCrop
-    card={stubCard}
-    playedCrop={stubPlayedCrop}
+    cropCardProps={stubCropCardProps}
     isInBackground={false}
     {...overrides}
   />

--- a/src/app/components/PlayedCrop/PlayedCrop.test.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+
+import { carrot } from '../../../game/cards'
+import { IPlayedCrop } from '../../../game/types'
+
+import { PlayedCrop, PlayedCropProps } from './PlayedCrop'
+
+const stubCard = carrot
+const stubWaterCards = 3
+const stubPlayedCrop: IPlayedCrop = {
+  id: stubCard.id,
+  waterCards: stubWaterCards,
+}
+
+const StubCropCard = (overrides: Partial<PlayedCropProps> = {}) => (
+  <PlayedCrop
+    card={stubCard}
+    playedCrop={stubPlayedCrop}
+    isInBackground={false}
+    {...overrides}
+  />
+)
+
+describe('PlayedCrop', () => {
+  test('renders played crop card', () => {
+    render(<StubCropCard />)
+
+    expect(screen.findByText(stubCard.name))
+  })
+
+  test('renders water indicators', () => {
+    render(<StubCropCard />)
+
+    expect(screen.getAllByAltText('Water card indicator')).toHaveLength(
+      stubWaterCards
+    )
+  })
+})

--- a/src/app/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.tsx
@@ -10,7 +10,7 @@ import { Card, CropCardProps } from '../Card'
 import { Image } from '../Image'
 import { cards } from '../../img'
 
-interface PlayedCropProps extends CropCardProps {
+export interface PlayedCropProps extends CropCardProps {
   playedCrop: IPlayedCrop
   cardSx?: CropCardProps['sx']
   isInBackground: boolean
@@ -41,6 +41,7 @@ export const PlayedCrop = ({
             <Grid key={idx} item sx={{ pt: `${theme.spacing(0)} !important` }}>
               <Image
                 src={cards.water}
+                alt="Water card indicator"
                 sx={{
                   imageRendering: 'pixelated',
                   opacity: isInBackground ? 0 : 1,

--- a/src/app/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.tsx
@@ -13,10 +13,16 @@ import { cards } from '../../img'
 interface PlayedCropProps extends CropCardProps {
   playedCrop: IPlayedCrop
   cardSx?: CropCardProps['sx']
+  isInBackground: boolean
   sx?: BoxProps['sx']
 }
 
-export const PlayedCrop = ({ sx, cardSx, ...props }: PlayedCropProps) => {
+export const PlayedCrop = ({
+  sx,
+  cardSx,
+  isInBackground,
+  ...props
+}: PlayedCropProps) => {
   const { playedCrop, size = CardSize.MEDIUM } = props
   const theme = useTheme()
 
@@ -33,7 +39,14 @@ export const PlayedCrop = ({ sx, cardSx, ...props }: PlayedCropProps) => {
         {new Array(playedCrop.waterCards).fill(null).map((_, idx) => {
           return (
             <Grid key={idx} item sx={{ pt: `${theme.spacing(0)} !important` }}>
-              <Image src={cards.water} sx={{ imageRendering: 'pixelated' }} />
+              <Image
+                src={cards.water}
+                sx={{
+                  imageRendering: 'pixelated',
+                  opacity: isInBackground ? 0 : 1,
+                  transition: theme.transitions.create(['opacity']),
+                }}
+              />
             </Grid>
           )
         })}

--- a/src/app/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.tsx
@@ -1,0 +1,10 @@
+import { IPlayedCrop } from '../../../game/types'
+import { Card, CropCardProps } from '../Card'
+
+interface PlayedCropProps extends CropCardProps {
+  playedCrop: IPlayedCrop
+}
+
+export const PlayedCrop = ({ ...rest }: PlayedCropProps) => {
+  return <Card {...rest} />
+}

--- a/src/app/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.tsx
@@ -15,6 +15,8 @@ export interface PlayedCropProps extends BoxProps {
   cropCardProps: CropCardProps & { playedCrop: IPlayedCrop }
 }
 
+export const playedCropWrapperClassName = 'PlayedCrop'
+
 export const PlayedCrop = ({
   isInBackground,
   cropCardProps,
@@ -24,7 +26,11 @@ export const PlayedCrop = ({
   const theme = useTheme()
 
   return (
-    <Box maxWidth={CARD_DIMENSIONS[size].width} {...props}>
+    <Box
+      className={playedCropWrapperClassName}
+      maxWidth={CARD_DIMENSIONS[size].width}
+      {...props}
+    >
       <Card size={size} {...cropCardProps} />
       <Grid
         container

--- a/src/app/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.tsx
@@ -10,25 +10,22 @@ import { Card, CropCardProps } from '../Card'
 import { Image } from '../Image'
 import { cards } from '../../img'
 
-export interface PlayedCropProps extends CropCardProps {
-  playedCrop: IPlayedCrop
-  cardSx?: CropCardProps['sx']
+export interface PlayedCropProps extends BoxProps {
   isInBackground: boolean
-  sx?: BoxProps['sx']
+  cropCardProps: CropCardProps & { playedCrop: IPlayedCrop }
 }
 
 export const PlayedCrop = ({
-  sx,
-  cardSx,
   isInBackground,
+  cropCardProps,
   ...props
 }: PlayedCropProps) => {
-  const { playedCrop, size = CardSize.MEDIUM } = props
+  const { playedCrop, size = CardSize.MEDIUM } = cropCardProps
   const theme = useTheme()
 
   return (
-    <Box maxWidth={CARD_DIMENSIONS[size].width} sx={sx}>
-      <Card size={size} sx={cardSx} {...props} />
+    <Box maxWidth={CARD_DIMENSIONS[size].width} {...props}>
+      <Card size={size} {...cropCardProps} />
       <Grid
         container
         spacing={1}

--- a/src/app/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.tsx
@@ -1,4 +1,5 @@
 import { IPlayedCrop } from '../../../game/types'
+import { CardSize } from '../../types'
 import { Card, CropCardProps } from '../Card'
 
 interface PlayedCropProps extends CropCardProps {
@@ -6,5 +7,5 @@ interface PlayedCropProps extends CropCardProps {
 }
 
 export const PlayedCrop = ({ ...rest }: PlayedCropProps) => {
-  return <Card {...rest} />
+  return <Card size={CardSize.MEDIUM} {...rest} />
 }

--- a/src/app/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.tsx
@@ -1,11 +1,43 @@
+import Box, { BoxProps } from '@mui/material/Box'
+import Grid from '@mui/material/Grid'
+
+import { useTheme } from '@mui/material'
+
 import { IPlayedCrop } from '../../../game/types'
+import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { CardSize } from '../../types'
 import { Card, CropCardProps } from '../Card'
+import { Image } from '../Image'
+import { cards } from '../../img'
 
 interface PlayedCropProps extends CropCardProps {
   playedCrop: IPlayedCrop
+  cardSx?: CropCardProps['sx']
+  sx?: BoxProps['sx']
 }
 
-export const PlayedCrop = ({ ...rest }: PlayedCropProps) => {
-  return <Card size={CardSize.MEDIUM} {...rest} />
+export const PlayedCrop = ({ sx, cardSx, ...props }: PlayedCropProps) => {
+  const { playedCrop, size = CardSize.MEDIUM } = props
+  const theme = useTheme()
+
+  return (
+    <Box maxWidth={CARD_DIMENSIONS[size].width} sx={sx}>
+      <Card size={size} sx={cardSx} {...props} />
+      <Grid
+        container
+        spacing={1}
+        pt={2.5}
+        ml={theme.spacing(-0.5)}
+        justifyContent="flex-start"
+      >
+        {new Array(playedCrop.waterCards).fill(null).map((_, idx) => {
+          return (
+            <Grid key={idx} item sx={{ pt: `${theme.spacing(0)} !important` }}>
+              <Image src={cards.water} sx={{ imageRendering: 'pixelated' }} />
+            </Grid>
+          )
+        })}
+      </Grid>
+    </Box>
+  )
 }

--- a/src/app/components/PlayedCrop/index.ts
+++ b/src/app/components/PlayedCrop/index.ts
@@ -1,0 +1,1 @@
+export * from './PlayedCrop'

--- a/src/app/config/dimensions.ts
+++ b/src/app/config/dimensions.ts
@@ -1,2 +1,18 @@
-export const CARD_WIDTH = '16rem'
+import { CardSize } from '../types'
+
 export const CARD_HEIGHT = '28rem'
+
+export const CARD_DIMENSIONS = {
+  [CardSize.SMALL]: {
+    height: '14rem',
+    width: '8rem',
+  },
+  [CardSize.MEDIUM]: {
+    height: '21rem',
+    width: '12rem',
+  },
+  [CardSize.LARGE]: {
+    height: '28rem',
+    width: '16rem',
+  },
+}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,0 +1,5 @@
+export enum CardSize {
+  SMALL = 'SMALL',
+  MEDIUM = 'MEDIUM',
+  LARGE = 'LARGE',
+}

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -7,3 +7,5 @@ export const DECK_SIZE = 60
 export const STANDARD_TAX_AMOUNT = 5
 
 export const STANDARD_FIELD_SIZE = 6
+
+export const SELECTED_CARD_ELEVATION = 10


### PR DESCRIPTION
### What this PR does

This PR implements the `<Field />` component. It also adds support for three different card sizes.

### How this change can be validated

Play around with the Field component in Storybook and ensure it works intuitively. Make sure that tab navigation works as well as pressing the `escape` key to reset the selection.

### Additional information

Player's field:

[Screencast of player Field](https://github.com/jeremyckahn/farmhand-shuffle/assets/366330/b7257301-4d8d-4b13-85a9-b9bfdf39096c)

Opponent player's field:

[Screencast of opponent player Field](https://github.com/jeremyckahn/farmhand-shuffle/assets/366330/81025ca7-5e96-4d2f-9ada-0334a6a42610)

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->
