### PR TITLE
feat(ui): Card flipping

### DIFF
--- a/src/app/components/Card/Card.stories.ts
+++ b/src/app/components/Card/Card.stories.ts
@@ -21,12 +21,14 @@ type Story = StoryObj<typeof meta>
 export const CropCard: Story = {
   args: {
     card: carrot,
+    isFlipped: false,
   },
 }
 
 export const WaterCard: Story = {
   args: {
     card: water,
+    isFlipped: false,
   },
 }
 
@@ -34,18 +36,21 @@ export const SmallCard: Story = {
   args: {
     card: pumpkin,
     size: CardSize.SMALL,
+    isFlipped: false,
   },
 }
 
 export const MediumCard: Story = {
   args: {
     card: pumpkin,
+    isFlipped: false,
     size: CardSize.MEDIUM,
   },
 }
 export const LargeCard: Story = {
   args: {
     card: pumpkin,
+    isFlipped: false,
     size: CardSize.LARGE,
   },
 }

--- a/src/app/components/Card/Card.test.tsx
+++ b/src/app/components/Card/Card.test.tsx
@@ -4,24 +4,24 @@ import { screen } from '@testing-library/dom'
 import { carrot } from '../../../game/cards'
 
 import { Card, CardProps } from './Card'
-import { cardClassName } from './CardTemplate'
+import { card3DWrapperClassName, cardClassName } from './CardTemplate'
 
 const stubCard = carrot
 
-const StubCropCard = (overrides: Partial<CardProps> = {}) => (
+const StubCard = (overrides: Partial<CardProps> = {}) => (
   <Card card={stubCard} {...overrides} />
 )
 
 describe('Card', () => {
   test('renders card', () => {
-    render(<StubCropCard />)
+    render(<StubCard />)
 
     expect(screen.findByText(stubCard.name))
     expect(screen.findByAltText(stubCard.name))
   })
 
   test('renders crop water requirements', () => {
-    render(<StubCropCard />)
+    render(<StubCard />)
 
     expect(
       screen.findByText(`Water needed to mature: ${stubCard.waterToMature}`)
@@ -30,7 +30,8 @@ describe('Card', () => {
 
   test('renders played crop card', () => {
     const waterCards = 1
-    render(<StubCropCard playedCrop={{ id: stubCard.id, waterCards }} />)
+
+    render(<StubCard playedCrop={{ id: stubCard.id, waterCards }} />)
 
     expect(
       screen.findByText(
@@ -40,7 +41,8 @@ describe('Card', () => {
   })
 
   test('is face up by default', () => {
-    render(<StubCropCard />)
+    render(<StubCard />)
+
     const card = screen.getByText(stubCard.name).closest(`.${cardClassName}`)
 
     const { transform } = getComputedStyle(card!)
@@ -48,10 +50,31 @@ describe('Card', () => {
   })
 
   test('can be flipped face down', () => {
-    render(<StubCropCard isFlipped={true} />)
+    render(<StubCard isFlipped={true} />)
+
     const card = screen.getByText(stubCard.name).closest(`.${cardClassName}`)
 
     const { transform } = getComputedStyle(card!)
     expect(transform).toEqual('rotateY(180deg)')
+  })
+
+  test('uses 3D perspective when not being transformed by parent component', () => {
+    render(<StubCard />)
+
+    const cardWrapper = screen
+      .getByText(stubCard.name)
+      .closest(`.${card3DWrapperClassName}`)
+
+    expect(cardWrapper).toBeInTheDocument()
+  })
+
+  test('can be transformed without distortion by parent component', () => {
+    render(<StubCard sx={{ transform: 'translateX(100px)' }} />)
+
+    const cardWrapper = screen
+      .getByText(stubCard.name)
+      .closest(`.${card3DWrapperClassName}`)
+
+    expect(cardWrapper).not.toBeInTheDocument()
   })
 })

--- a/src/app/components/Card/Card.test.tsx
+++ b/src/app/components/Card/Card.test.tsx
@@ -4,7 +4,10 @@ import { screen } from '@testing-library/dom'
 import { carrot } from '../../../game/cards'
 
 import { Card, CardProps } from './Card'
-import { card3DWrapperClassName, cardClassName } from './CardTemplate'
+import {
+  card3DPerspectiveWrapperClassName,
+  cardClassName,
+} from './CardTemplate'
 
 const stubCard = carrot
 
@@ -63,7 +66,7 @@ describe('Card', () => {
 
     const cardWrapper = screen
       .getByText(stubCard.name)
-      .closest(`.${card3DWrapperClassName}`)
+      .closest(`.${card3DPerspectiveWrapperClassName}`)
 
     expect(cardWrapper).toBeInTheDocument()
   })
@@ -73,7 +76,7 @@ describe('Card', () => {
 
     const cardWrapper = screen
       .getByText(stubCard.name)
-      .closest(`.${card3DWrapperClassName}`)
+      .closest(`.${card3DPerspectiveWrapperClassName}`)
 
     expect(cardWrapper).not.toBeInTheDocument()
   })

--- a/src/app/components/Card/Card.test.tsx
+++ b/src/app/components/Card/Card.test.tsx
@@ -3,11 +3,12 @@ import { screen } from '@testing-library/dom'
 
 import { carrot } from '../../../game/cards'
 
-import { Card, CropCardProps } from './Card'
+import { Card, CardProps } from './Card'
+import { cardClassName } from './CardTemplate'
 
 const stubCard = carrot
 
-const StubCropCard = (overrides: Partial<CropCardProps> = {}) => (
+const StubCropCard = (overrides: Partial<CardProps> = {}) => (
   <Card card={stubCard} {...overrides} />
 )
 
@@ -36,5 +37,21 @@ describe('Card', () => {
         `Water cards attached: ${waterCards}/${stubCard.waterToMature}`
       )
     )
+  })
+
+  test('is face up by default', () => {
+    render(<StubCropCard />)
+    const card = screen.getByText(stubCard.name).closest(`.${cardClassName}`)
+
+    const { transform } = getComputedStyle(card!)
+    expect(transform).toEqual('')
+  })
+
+  test('can be flipped face down', () => {
+    render(<StubCropCard isFlipped={true} />)
+    const card = screen.getByText(stubCard.name).closest(`.${cardClassName}`)
+
+    const { transform } = getComputedStyle(card!)
+    expect(transform).toEqual('rotateY(180deg)')
   })
 })

--- a/src/app/components/Card/Card.test.tsx
+++ b/src/app/components/Card/Card.test.tsx
@@ -4,10 +4,7 @@ import { screen } from '@testing-library/dom'
 import { carrot } from '../../../game/cards'
 
 import { Card, CardProps } from './Card'
-import {
-  card3DPerspectiveWrapperClassName,
-  cardClassName,
-} from './CardTemplate'
+import { cardFlipWrapperClassName } from './CardTemplate'
 
 const stubCard = carrot
 
@@ -46,7 +43,9 @@ describe('Card', () => {
   test('is face up by default', () => {
     render(<StubCard />)
 
-    const card = screen.getByText(stubCard.name).closest(`.${cardClassName}`)
+    const card = screen
+      .getByText(stubCard.name)
+      .closest(`.${cardFlipWrapperClassName}`)
 
     const { transform } = getComputedStyle(card!)
     expect(transform).toEqual('')
@@ -55,29 +54,11 @@ describe('Card', () => {
   test('can be flipped face down', () => {
     render(<StubCard isFlipped={true} />)
 
-    const card = screen.getByText(stubCard.name).closest(`.${cardClassName}`)
+    const card = screen
+      .getByText(stubCard.name)
+      .closest(`.${cardFlipWrapperClassName}`)
 
     const { transform } = getComputedStyle(card!)
     expect(transform).toEqual('rotateY(180deg)')
-  })
-
-  test('uses 3D perspective when not being transformed by parent component', () => {
-    render(<StubCard />)
-
-    const cardWrapper = screen
-      .getByText(stubCard.name)
-      .closest(`.${card3DPerspectiveWrapperClassName}`)
-
-    expect(cardWrapper).toBeInTheDocument()
-  })
-
-  test('can be transformed without distortion by parent component', () => {
-    render(<StubCard sx={{ transform: 'translateX(100px)' }} />)
-
-    const cardWrapper = screen
-      .getByText(stubCard.name)
-      .closest(`.${card3DPerspectiveWrapperClassName}`)
-
-    expect(cardWrapper).not.toBeInTheDocument()
   })
 })

--- a/src/app/components/Card/Card.tsx
+++ b/src/app/components/Card/Card.tsx
@@ -27,6 +27,7 @@ export interface CropCardProps extends BaseCardProps {
 export interface WaterCardProps extends BaseCardProps {}
 
 export type CardProps = (CropCardProps | WaterCardProps) & {
+  isFlipped?: boolean
   paperProps?: Partial<Omit<PaperProps, 'sx'>>
 }
 

--- a/src/app/components/Card/Card.tsx
+++ b/src/app/components/Card/Card.tsx
@@ -1,3 +1,4 @@
+import { BoxProps } from '@mui/material/Box'
 import { PaperProps } from '@mui/material/Paper'
 
 import { UnimplementedError } from '../../../game/services/Rules/errors'
@@ -13,7 +14,7 @@ import { CardSize } from '../../types'
 import { CardCropText } from './CardCropText'
 import { CardTemplate } from './CardTemplate'
 
-export interface BaseCardProps extends PaperProps {
+export interface BaseCardProps extends BoxProps {
   card: ICard
   size?: CardSize
   imageScale?: number
@@ -25,7 +26,9 @@ export interface CropCardProps extends BaseCardProps {
 
 export interface WaterCardProps extends BaseCardProps {}
 
-export type CardProps = CropCardProps | WaterCardProps
+export type CardProps = (CropCardProps | WaterCardProps) & {
+  paperProps?: Partial<Omit<PaperProps, 'sx'>>
+}
 
 const isPropsCropCardProps = (props: CardProps): props is CropCardProps => {
   return isCropCard(props.card)

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -33,100 +33,108 @@ export const CardTemplate = ({
 
   return (
     <Box
-      className={cardClassName}
-      sx={[
-        {
-          height: CARD_DIMENSIONS[size].height,
-          position: 'relative',
-          transformStyle: 'preserve-3d',
-          transition: theme.transitions.create(['transform']),
-          width: CARD_DIMENSIONS[size].width,
-          ...(isFlipped && {
-            transform: 'rotateY(180deg)',
-          }),
-        },
-        ...(Array.isArray(sx) ? sx : [sx]),
-      ]}
-      {...props}
+      sx={{
+        perspective: '1000px',
+        height: CARD_DIMENSIONS[size].height,
+        width: CARD_DIMENSIONS[size].width,
+      }}
     >
-      <Paper
-        {...paperProps}
+      <Box
+        className={cardClassName}
         sx={[
           {
-            backfaceVisibility: 'hidden',
-            background:
-              theme.palette.mode === 'light'
-                ? darken(theme.palette.background.paper, 0.05)
-                : lighten(theme.palette.background.paper, 0.15),
-            display: 'flex',
-            flexDirection: 'column',
             height: 1,
-            p: theme.spacing(1),
-            position: 'absolute',
+            position: 'relative',
+            transformStyle: 'preserve-3d',
+            transition: theme.transitions.create(['transform']),
             width: 1,
+            ...(isFlipped && {
+              transform: 'rotateY(180deg)',
+            }),
           },
+          ...(Array.isArray(sx) ? sx : [sx]),
         ]}
+        {...props}
       >
-        <Typography
-          variant="overline"
-          sx={{ fontWeight: theme.typography.fontWeightBold }}
+        <Paper
+          {...paperProps}
+          sx={[
+            {
+              backfaceVisibility: 'hidden',
+              background:
+                theme.palette.mode === 'light'
+                  ? darken(theme.palette.background.paper, 0.05)
+                  : lighten(theme.palette.background.paper, 0.15),
+              display: 'flex',
+              flexDirection: 'column',
+              height: 1,
+              p: theme.spacing(1),
+              position: 'absolute',
+              width: 1,
+            },
+          ]}
         >
-          {card.name}
-        </Typography>
-        <Box
-          sx={{
-            height: '50%',
-            display: 'flex',
-            background: theme.palette.common.white,
-            backgroundImage: `url(${ui.dirt})`,
-            backgroundSize: '100%',
-            backgroundRepeat: 'repeat',
-            borderColor: theme.palette.divider,
-            borderRadius: `${theme.shape.borderRadius}px`,
-            borderWidth: 1,
-            borderStyle: 'solid',
-            imageRendering: 'pixelated',
-          }}
-        >
-          <Image
-            src={imageSrc}
-            alt={card.name}
+          <Typography
+            variant="overline"
+            sx={{ fontWeight: theme.typography.fontWeightBold }}
+          >
+            {card.name}
+          </Typography>
+          <Box
             sx={{
-              height: `${100 * imageScale}%`,
-              p: 0,
-              m: 'auto',
+              height: '50%',
+              display: 'flex',
+              background: theme.palette.common.white,
+              backgroundImage: `url(${ui.dirt})`,
+              backgroundSize: '100%',
+              backgroundRepeat: 'repeat',
+              borderColor: theme.palette.divider,
+              borderRadius: `${theme.shape.borderRadius}px`,
+              borderWidth: 1,
+              borderStyle: 'solid',
               imageRendering: 'pixelated',
-              filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
             }}
-          />
-        </Box>
-        <Divider sx={{ my: theme.spacing(1) }} />
-        <Box sx={{ height: '50%' }}>{children}</Box>
-      </Paper>
-      <Paper
-        {...paperProps}
-        sx={{
-          alignItems: 'center',
-          backfaceVisibility: 'hidden',
-          display: 'flex',
-          height: 1,
-          position: 'absolute',
-          textAlign: 'center',
-          transform: 'rotateY(180deg)',
-          width: 1,
-        }}
-      >
-        <Typography
-          variant="h1"
+          >
+            <Image
+              src={imageSrc}
+              alt={card.name}
+              sx={{
+                height: `${100 * imageScale}%`,
+                p: 0,
+                m: 'auto',
+                imageRendering: 'pixelated',
+                filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
+              }}
+            />
+          </Box>
+          <Divider sx={{ my: theme.spacing(1) }} />
+          <Box sx={{ height: '50%' }}>{children}</Box>
+        </Paper>
+        <Paper
+          {...paperProps}
           sx={{
-            fontSize: theme.typography.h4.fontSize,
-            fontWeight: theme.typography.h4.fontWeight,
-            lineHeight: theme.typography.h4.lineHeight,
+            alignItems: 'center',
+            backfaceVisibility: 'hidden',
+            display: 'flex',
+            height: 1,
+            position: 'absolute',
+            textAlign: 'center',
+            transform: 'rotateY(180deg)',
+            width: 1,
           }}
         >
-          Farmhand Shuffle
-        </Typography>
-      </Paper>
+          <Typography
+            variant="h1"
+            sx={{
+              fontSize: theme.typography.h4.fontSize,
+              fontWeight: theme.typography.h4.fontWeight,
+              lineHeight: theme.typography.h4.lineHeight,
+            }}
+          >
+            Farmhand Shuffle
+          </Typography>
+        </Paper>
+      </Box>
     </Box>
   )
 }

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -20,10 +20,10 @@ export const CardTemplate = ({
   size = CardSize.MEDIUM,
   sx = [],
   children,
+  paperProps,
   ...props
 }: CardProps) => {
   const theme = useTheme()
-
   const imageSrc = isCardImageKey(card.id) ? cards[card.id] : ui.pixel
 
   if (imageSrc === ui.pixel) {
@@ -31,60 +31,64 @@ export const CardTemplate = ({
   }
 
   return (
-    <Paper
+    <Box
       className={cardClassName}
-      sx={[
-        {
-          width: CARD_DIMENSIONS[size].width,
-          height: CARD_DIMENSIONS[size].height,
-          background:
-            theme.palette.mode === 'light'
-              ? darken(theme.palette.background.paper, 0.05)
-              : lighten(theme.palette.background.paper, 0.15),
-          display: 'flex',
-          flexDirection: 'column',
-          p: theme.spacing(1),
-          position: 'relative',
-        },
-        ...(Array.isArray(sx) ? sx : [sx]),
-      ]}
+      sx={[...(Array.isArray(sx) ? sx : [sx])]}
       {...props}
     >
-      <Typography
-        variant="overline"
-        sx={{ fontWeight: theme.typography.fontWeightBold }}
+      <Paper
+        {...paperProps}
+        sx={[
+          {
+            width: CARD_DIMENSIONS[size].width,
+            height: CARD_DIMENSIONS[size].height,
+            background:
+              theme.palette.mode === 'light'
+                ? darken(theme.palette.background.paper, 0.05)
+                : lighten(theme.palette.background.paper, 0.15),
+            display: 'flex',
+            flexDirection: 'column',
+            p: theme.spacing(1),
+            position: 'relative',
+          },
+        ]}
       >
-        {card.name}
-      </Typography>
-      <Box
-        sx={{
-          height: '50%',
-          display: 'flex',
-          background: theme.palette.common.white,
-          backgroundImage: `url(${ui.dirt})`,
-          backgroundSize: '100%',
-          backgroundRepeat: 'repeat',
-          borderColor: theme.palette.divider,
-          borderRadius: `${theme.shape.borderRadius}px`,
-          borderWidth: 1,
-          borderStyle: 'solid',
-          imageRendering: 'pixelated',
-        }}
-      >
-        <Image
-          src={imageSrc}
-          alt={card.name}
+        <Typography
+          variant="overline"
+          sx={{ fontWeight: theme.typography.fontWeightBold }}
+        >
+          {card.name}
+        </Typography>
+        <Box
           sx={{
-            height: `${100 * imageScale}%`,
-            p: 0,
-            m: 'auto',
+            height: '50%',
+            display: 'flex',
+            background: theme.palette.common.white,
+            backgroundImage: `url(${ui.dirt})`,
+            backgroundSize: '100%',
+            backgroundRepeat: 'repeat',
+            borderColor: theme.palette.divider,
+            borderRadius: `${theme.shape.borderRadius}px`,
+            borderWidth: 1,
+            borderStyle: 'solid',
             imageRendering: 'pixelated',
-            filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
           }}
-        />
-      </Box>
-      <Divider sx={{ my: theme.spacing(1) }} />
-      <Box sx={{ height: '50%' }}>{children}</Box>
-    </Paper>
+        >
+          <Image
+            src={imageSrc}
+            alt={card.name}
+            sx={{
+              height: `${100 * imageScale}%`,
+              p: 0,
+              m: 'auto',
+              imageRendering: 'pixelated',
+              filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
+            }}
+          />
+        </Box>
+        <Divider sx={{ my: theme.spacing(1) }} />
+        <Box sx={{ height: '50%' }}>{children}</Box>
+      </Paper>
+    </Box>
   )
 }

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -12,6 +12,7 @@ import { CardSize } from '../../types'
 
 import { CardProps } from './Card'
 
+export const card3DWrapperClassName = 'Card3DWrapper'
 export const cardClassName = 'Card'
 
 export const CardTemplate = ({
@@ -33,6 +34,7 @@ export const CardTemplate = ({
 
   return (
     <Box
+      className={card3DWrapperClassName}
       sx={{
         perspective: '1000px',
         height: CARD_DIMENSIONS[size].height,

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -3,7 +3,7 @@ import Paper from '@mui/material/Paper'
 import Divider from '@mui/material/Divider'
 import useTheme from '@mui/material/styles/useTheme'
 import Typography from '@mui/material/Typography'
-import { SxProps, darken, lighten } from '@mui/material/styles'
+import { darken, lighten } from '@mui/material/styles'
 
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { cards, isCardImageKey, ui } from '../../img'
@@ -12,8 +12,8 @@ import { CardSize } from '../../types'
 
 import { CardProps } from './Card'
 
-export const card3DPerspectiveWrapperClassName = 'Card3DWrapper'
 export const cardClassName = 'Card'
+export const cardFlipWrapperClassName = 'CardFlipWrapper'
 
 export const CardTemplate = ({
   card,
@@ -32,128 +32,111 @@ export const CardTemplate = ({
     console.error(`Card ID ${card.id} does not have an image configured`)
   }
 
-  const sxArray: SxProps = Array.isArray(sx) ? sx : [sx]
-  const isBeingTransformed = sxArray.some(
-    sx => typeof sx === 'object' && sx !== null && 'transform' in sx
-  )
-
-  const baseCard = (
+  return (
     <Box
       className={cardClassName}
       sx={[
         {
+          perspective: '1000px',
           height: CARD_DIMENSIONS[size].height,
-          position: 'relative',
-          transformStyle: 'preserve-3d',
-          transition: theme.transitions.create(['transform']),
           width: CARD_DIMENSIONS[size].width,
-          ...(isFlipped && {
-            transform: 'rotateY(180deg)',
-          }),
         },
-        ...sxArray,
+        ...(Array.isArray(sx) ? sx : [sx]),
       ]}
       {...props}
     >
-      <Paper
-        {...paperProps}
+      <Box
+        className={cardFlipWrapperClassName}
         sx={[
           {
-            backfaceVisibility: 'hidden',
-            background:
-              theme.palette.mode === 'light'
-                ? darken(theme.palette.background.paper, 0.05)
-                : lighten(theme.palette.background.paper, 0.15),
-            display: 'flex',
-            flexDirection: 'column',
-            height: 1,
-            p: theme.spacing(1),
-            position: 'absolute',
-            width: 1,
+            height: CARD_DIMENSIONS[size].height,
+            position: 'relative',
+            transformStyle: 'preserve-3d',
+            transition: theme.transitions.create(['transform']),
+            width: CARD_DIMENSIONS[size].width,
+            ...(isFlipped && {
+              transform: 'rotateY(180deg)',
+            }),
           },
         ]}
       >
-        <Typography
-          variant="overline"
-          sx={{ fontWeight: theme.typography.fontWeightBold }}
+        <Paper
+          {...paperProps}
+          sx={[
+            {
+              backfaceVisibility: 'hidden',
+              background:
+                theme.palette.mode === 'light'
+                  ? darken(theme.palette.background.paper, 0.05)
+                  : lighten(theme.palette.background.paper, 0.15),
+              display: 'flex',
+              flexDirection: 'column',
+              height: 1,
+              p: theme.spacing(1),
+              position: 'absolute',
+              width: 1,
+            },
+          ]}
         >
-          {card.name}
-        </Typography>
-        <Box
-          sx={{
-            height: '50%',
-            display: 'flex',
-            background: theme.palette.common.white,
-            backgroundImage: `url(${ui.dirt})`,
-            backgroundSize: '100%',
-            backgroundRepeat: 'repeat',
-            borderColor: theme.palette.divider,
-            borderRadius: `${theme.shape.borderRadius}px`,
-            borderWidth: 1,
-            borderStyle: 'solid',
-            imageRendering: 'pixelated',
-          }}
-        >
-          <Image
-            src={imageSrc}
-            alt={card.name}
+          <Typography
+            variant="overline"
+            sx={{ fontWeight: theme.typography.fontWeightBold }}
+          >
+            {card.name}
+          </Typography>
+          <Box
             sx={{
-              height: `${100 * imageScale}%`,
-              p: 0,
-              m: 'auto',
+              height: '50%',
+              display: 'flex',
+              background: theme.palette.common.white,
+              backgroundImage: `url(${ui.dirt})`,
+              backgroundSize: '100%',
+              backgroundRepeat: 'repeat',
+              borderColor: theme.palette.divider,
+              borderRadius: `${theme.shape.borderRadius}px`,
+              borderWidth: 1,
+              borderStyle: 'solid',
               imageRendering: 'pixelated',
-              filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
             }}
-          />
-        </Box>
-        <Divider sx={{ my: theme.spacing(1) }} />
-        <Box sx={{ height: '50%' }}>{children}</Box>
-      </Paper>
-      <Paper
-        {...paperProps}
-        sx={{
-          alignItems: 'center',
-          backfaceVisibility: 'hidden',
-          display: 'flex',
-          height: 1,
-          position: 'absolute',
-          textAlign: 'center',
-          transform: 'rotateY(180deg)',
-          width: 1,
-        }}
-      >
-        <Typography
-          variant="h2"
+          >
+            <Image
+              src={imageSrc}
+              alt={card.name}
+              sx={{
+                height: `${100 * imageScale}%`,
+                p: 0,
+                m: 'auto',
+                imageRendering: 'pixelated',
+                filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
+              }}
+            />
+          </Box>
+          <Divider sx={{ my: theme.spacing(1) }} />
+          <Box sx={{ height: '50%' }}>{children}</Box>
+        </Paper>
+        <Paper
+          {...paperProps}
           sx={{
-            ...theme.typography.h4,
+            alignItems: 'center',
+            backfaceVisibility: 'hidden',
+            display: 'flex',
+            height: 1,
+            position: 'absolute',
+            textAlign: 'center',
+            transform: 'rotateY(180deg)',
+            width: 1,
           }}
         >
-          Farmhand Shuffle
-        </Typography>
-      </Paper>
-    </Box>
-  )
-
-  // NOTE: If the card is being transformed by the parent component, the
-  // perspective wrapper will visually distort it. To avoid that, return the
-  // base card to be rendered directly.
-  if (isBeingTransformed) {
-    return baseCard
-  }
-
-  // NOTE: If the card is not being transformed by the parent component, render
-  // it in a wrapper with styles that will result in a 3D effect to enhance the
-  // card flip animation.
-  return (
-    <Box
-      className={card3DPerspectiveWrapperClassName}
-      sx={{
-        perspective: '1000px',
-        height: CARD_DIMENSIONS[size].height,
-        width: CARD_DIMENSIONS[size].width,
-      }}
-    >
-      {baseCard}
+          <Typography
+            variant="h2"
+            sx={{
+              ...theme.typography.h4,
+            }}
+          >
+            Farmhand Shuffle
+          </Typography>
+        </Paper>
+      </Box>
     </Box>
   )
 }

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -16,11 +16,12 @@ export const cardClassName = 'Card'
 
 export const CardTemplate = ({
   card,
+  children,
   imageScale = 0.75,
+  isFlipped = false,
+  paperProps,
   size = CardSize.MEDIUM,
   sx = [],
-  children,
-  paperProps,
   ...props
 }: CardProps) => {
   const theme = useTheme()
@@ -33,23 +34,36 @@ export const CardTemplate = ({
   return (
     <Box
       className={cardClassName}
-      sx={[...(Array.isArray(sx) ? sx : [sx])]}
+      sx={[
+        {
+          height: CARD_DIMENSIONS[size].height,
+          position: 'relative',
+          transformStyle: 'preserve-3d',
+          transition: theme.transitions.create(['transform']),
+          width: CARD_DIMENSIONS[size].width,
+          ...(isFlipped && {
+            transform: 'rotateY(180deg)',
+          }),
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
       {...props}
     >
       <Paper
         {...paperProps}
         sx={[
           {
-            width: CARD_DIMENSIONS[size].width,
-            height: CARD_DIMENSIONS[size].height,
+            backfaceVisibility: 'hidden',
             background:
               theme.palette.mode === 'light'
                 ? darken(theme.palette.background.paper, 0.05)
                 : lighten(theme.palette.background.paper, 0.15),
             display: 'flex',
             flexDirection: 'column',
+            height: 1,
             p: theme.spacing(1),
-            position: 'relative',
+            position: 'absolute',
+            width: 1,
           },
         ]}
       >
@@ -88,6 +102,30 @@ export const CardTemplate = ({
         </Box>
         <Divider sx={{ my: theme.spacing(1) }} />
         <Box sx={{ height: '50%' }}>{children}</Box>
+      </Paper>
+      <Paper
+        {...paperProps}
+        sx={{
+          alignItems: 'center',
+          backfaceVisibility: 'hidden',
+          display: 'flex',
+          height: 1,
+          position: 'absolute',
+          textAlign: 'center',
+          transform: 'rotateY(180deg)',
+          width: 1,
+        }}
+      >
+        <Typography
+          variant="h1"
+          sx={{
+            fontSize: theme.typography.h4.fontSize,
+            fontWeight: theme.typography.h4.fontWeight,
+            lineHeight: theme.typography.h4.lineHeight,
+          }}
+        >
+          Farmhand Shuffle
+        </Typography>
       </Paper>
     </Box>
   )

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -3,7 +3,7 @@ import Paper from '@mui/material/Paper'
 import Divider from '@mui/material/Divider'
 import useTheme from '@mui/material/styles/useTheme'
 import Typography from '@mui/material/Typography'
-import { darken, lighten } from '@mui/material/styles'
+import { SxProps, darken, lighten } from '@mui/material/styles'
 
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { cards, isCardImageKey, ui } from '../../img'
@@ -12,7 +12,7 @@ import { CardSize } from '../../types'
 
 import { CardProps } from './Card'
 
-export const card3DWrapperClassName = 'Card3DWrapper'
+export const card3DPerspectiveWrapperClassName = 'Card3DWrapper'
 export const cardClassName = 'Card'
 
 export const CardTemplate = ({
@@ -32,8 +32,10 @@ export const CardTemplate = ({
     console.error(`Card ID ${card.id} does not have an image configured`)
   }
 
-  const sxArray = Array.isArray(sx) ? sx : [sx]
-  const isBeingTransformed = sxArray.some(({ transform }) => Boolean(transform))
+  const sxArray: SxProps = Array.isArray(sx) ? sx : [sx]
+  const isBeingTransformed = sxArray.some(
+    sx => typeof sx === 'object' && sx !== null && 'transform' in sx
+  )
 
   const baseCard = (
     <Box
@@ -121,11 +123,9 @@ export const CardTemplate = ({
         }}
       >
         <Typography
-          variant="h1"
+          variant="h2"
           sx={{
-            fontSize: theme.typography.h4.fontSize,
-            fontWeight: theme.typography.h4.fontWeight,
-            lineHeight: theme.typography.h4.lineHeight,
+            ...theme.typography.h4,
           }}
         >
           Farmhand Shuffle
@@ -135,8 +135,8 @@ export const CardTemplate = ({
   )
 
   // NOTE: If the card is being transformed by the parent component, the
-  // perspective wrapper below will visually distort it. To avoid that, the
-  // base card is rendered directly.
+  // perspective wrapper will visually distort it. To avoid that, return the
+  // base card to be rendered directly.
   if (isBeingTransformed) {
     return baseCard
   }
@@ -146,7 +146,7 @@ export const CardTemplate = ({
   // card flip animation.
   return (
     <Box
-      className={card3DWrapperClassName}
+      className={card3DPerspectiveWrapperClassName}
       sx={{
         perspective: '1000px',
         height: CARD_DIMENSIONS[size].height,

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -32,6 +32,118 @@ export const CardTemplate = ({
     console.error(`Card ID ${card.id} does not have an image configured`)
   }
 
+  const sxArray = Array.isArray(sx) ? sx : [sx]
+  const isBeingTransformed = sxArray.some(({ transform }) => Boolean(transform))
+
+  const baseCard = (
+    <Box
+      className={cardClassName}
+      sx={[
+        {
+          height: CARD_DIMENSIONS[size].height,
+          position: 'relative',
+          transformStyle: 'preserve-3d',
+          transition: theme.transitions.create(['transform']),
+          width: CARD_DIMENSIONS[size].width,
+          ...(isFlipped && {
+            transform: 'rotateY(180deg)',
+          }),
+        },
+        ...sxArray,
+      ]}
+      {...props}
+    >
+      <Paper
+        {...paperProps}
+        sx={[
+          {
+            backfaceVisibility: 'hidden',
+            background:
+              theme.palette.mode === 'light'
+                ? darken(theme.palette.background.paper, 0.05)
+                : lighten(theme.palette.background.paper, 0.15),
+            display: 'flex',
+            flexDirection: 'column',
+            height: 1,
+            p: theme.spacing(1),
+            position: 'absolute',
+            width: 1,
+          },
+        ]}
+      >
+        <Typography
+          variant="overline"
+          sx={{ fontWeight: theme.typography.fontWeightBold }}
+        >
+          {card.name}
+        </Typography>
+        <Box
+          sx={{
+            height: '50%',
+            display: 'flex',
+            background: theme.palette.common.white,
+            backgroundImage: `url(${ui.dirt})`,
+            backgroundSize: '100%',
+            backgroundRepeat: 'repeat',
+            borderColor: theme.palette.divider,
+            borderRadius: `${theme.shape.borderRadius}px`,
+            borderWidth: 1,
+            borderStyle: 'solid',
+            imageRendering: 'pixelated',
+          }}
+        >
+          <Image
+            src={imageSrc}
+            alt={card.name}
+            sx={{
+              height: `${100 * imageScale}%`,
+              p: 0,
+              m: 'auto',
+              imageRendering: 'pixelated',
+              filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
+            }}
+          />
+        </Box>
+        <Divider sx={{ my: theme.spacing(1) }} />
+        <Box sx={{ height: '50%' }}>{children}</Box>
+      </Paper>
+      <Paper
+        {...paperProps}
+        sx={{
+          alignItems: 'center',
+          backfaceVisibility: 'hidden',
+          display: 'flex',
+          height: 1,
+          position: 'absolute',
+          textAlign: 'center',
+          transform: 'rotateY(180deg)',
+          width: 1,
+        }}
+      >
+        <Typography
+          variant="h1"
+          sx={{
+            fontSize: theme.typography.h4.fontSize,
+            fontWeight: theme.typography.h4.fontWeight,
+            lineHeight: theme.typography.h4.lineHeight,
+          }}
+        >
+          Farmhand Shuffle
+        </Typography>
+      </Paper>
+    </Box>
+  )
+
+  // NOTE: If the card is being transformed by the parent component, the
+  // perspective wrapper below will visually distort it. To avoid that, the
+  // base card is rendered directly.
+  if (isBeingTransformed) {
+    return baseCard
+  }
+
+  // NOTE: If the card is not being transformed by the parent component, render
+  // it in a wrapper with styles that will result in a 3D effect to enhance the
+  // card flip animation.
   return (
     <Box
       className={card3DWrapperClassName}
@@ -41,102 +153,7 @@ export const CardTemplate = ({
         width: CARD_DIMENSIONS[size].width,
       }}
     >
-      <Box
-        className={cardClassName}
-        sx={[
-          {
-            height: 1,
-            position: 'relative',
-            transformStyle: 'preserve-3d',
-            transition: theme.transitions.create(['transform']),
-            width: 1,
-            ...(isFlipped && {
-              transform: 'rotateY(180deg)',
-            }),
-          },
-          ...(Array.isArray(sx) ? sx : [sx]),
-        ]}
-        {...props}
-      >
-        <Paper
-          {...paperProps}
-          sx={[
-            {
-              backfaceVisibility: 'hidden',
-              background:
-                theme.palette.mode === 'light'
-                  ? darken(theme.palette.background.paper, 0.05)
-                  : lighten(theme.palette.background.paper, 0.15),
-              display: 'flex',
-              flexDirection: 'column',
-              height: 1,
-              p: theme.spacing(1),
-              position: 'absolute',
-              width: 1,
-            },
-          ]}
-        >
-          <Typography
-            variant="overline"
-            sx={{ fontWeight: theme.typography.fontWeightBold }}
-          >
-            {card.name}
-          </Typography>
-          <Box
-            sx={{
-              height: '50%',
-              display: 'flex',
-              background: theme.palette.common.white,
-              backgroundImage: `url(${ui.dirt})`,
-              backgroundSize: '100%',
-              backgroundRepeat: 'repeat',
-              borderColor: theme.palette.divider,
-              borderRadius: `${theme.shape.borderRadius}px`,
-              borderWidth: 1,
-              borderStyle: 'solid',
-              imageRendering: 'pixelated',
-            }}
-          >
-            <Image
-              src={imageSrc}
-              alt={card.name}
-              sx={{
-                height: `${100 * imageScale}%`,
-                p: 0,
-                m: 'auto',
-                imageRendering: 'pixelated',
-                filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
-              }}
-            />
-          </Box>
-          <Divider sx={{ my: theme.spacing(1) }} />
-          <Box sx={{ height: '50%' }}>{children}</Box>
-        </Paper>
-        <Paper
-          {...paperProps}
-          sx={{
-            alignItems: 'center',
-            backfaceVisibility: 'hidden',
-            display: 'flex',
-            height: 1,
-            position: 'absolute',
-            textAlign: 'center',
-            transform: 'rotateY(180deg)',
-            width: 1,
-          }}
-        >
-          <Typography
-            variant="h1"
-            sx={{
-              fontSize: theme.typography.h4.fontSize,
-              fontWeight: theme.typography.h4.fontWeight,
-              lineHeight: theme.typography.h4.lineHeight,
-            }}
-          >
-            Farmhand Shuffle
-          </Typography>
-        </Paper>
-      </Box>
+      {baseCard}
     </Box>
   )
 }

--- a/src/app/components/Hand/Hand.tsx
+++ b/src/app/components/Hand/Hand.tsx
@@ -139,7 +139,11 @@ export const Hand = ({
             key={`${cardId}_${idx}`}
             card={card}
             size={cardSize}
-            elevation={isSelected ? SELECTED_CARD_ELEVATION : undefined}
+            paperProps={{
+              ...(isSelected && {
+                elevation: SELECTED_CARD_ELEVATION,
+              }),
+            }}
             sx={{
               transform,
               position: 'absolute',


### PR DESCRIPTION
### What this PR does

This PR implements support for card flipping.

### How this change can be validated

In [the Card Storybook story,](https://farmhand-shuffle-git-feat-2d4940-jeremy-kahns-projects-98e6f140.vercel.app/storybook/?path=/story/farmhand-shuffle-card--large-card&globals=backgrounds.value:!hex(333333)) toggle the `isFlipped` switch and verify that the card is flipped appropriately.

I recommend disabling whitespace when viewing the diff.

### Questions or concerns about this change

~~I don't love the complexity that comes from conditionally rendering the card perspective wrapper `Box`. There may be a simpler way to do it, but I am not good enough at 3D math to know what that might be. :sob:~~

Update: I found and implemented a cleaner solution! 😃 https://github.com/jeremyckahn/farmhand-shuffle/commit/f0875126da2493334cbada8adf7729ab1d8ebec3

### Additional information

[Screencast of card flipping animation](https://github.com/user-attachments/assets/a432f621-d6f6-4566-91a9-881e3d8252df)

