### PR TITLE
feat(ui): Render Discard Pile

### DIFF
--- a/src/app/components/Card/Card.test.tsx
+++ b/src/app/components/Card/Card.test.tsx
@@ -8,7 +8,7 @@ import { cardFlipWrapperClassName } from './CardTemplate'
 
 const stubCard = carrot
 
-const StubCard = (overrides: Partial<CardProps> = {}) => (
+const StubCard = ({ ref, ...overrides }: Partial<CardProps> = {}) => (
   <Card card={stubCard} {...overrides} />
 )
 

--- a/src/app/components/Card/Card.tsx
+++ b/src/app/components/Card/Card.tsx
@@ -1,6 +1,8 @@
 import { BoxProps } from '@mui/material/Box'
 import { PaperProps } from '@mui/material/Paper'
 
+import { forwardRef } from 'react'
+
 import { UnimplementedError } from '../../../game/services/Rules/errors'
 import {
   ICard,
@@ -39,28 +41,38 @@ const isPropsWaterCardProps = (props: CardProps): props is WaterCardProps => {
   return isWaterCard(props.card)
 }
 
-export const CropCard = ({ playedCrop, ...props }: CropCardProps) => {
-  return (
-    <CardTemplate {...props}>
-      {isCrop(props.card) ? (
-        <CardCropText crop={props.card} playedCrop={playedCrop} />
-      ) : null}
-    </CardTemplate>
-  )
-}
+export const CropCard = forwardRef<HTMLDivElement, CropCardProps>(
+  ({ playedCrop, ...props }, ref) => {
+    return (
+      <CardTemplate {...props} ref={ref}>
+        {isCrop(props.card) ? (
+          <CardCropText crop={props.card} playedCrop={playedCrop} />
+        ) : null}
+      </CardTemplate>
+    )
+  }
+)
 
-export const WaterCard = (props: WaterCardProps) => {
-  return <CardTemplate {...props} />
-}
+CropCard.displayName = 'CropCard'
 
-export const Card = (props: CardProps) => {
+export const WaterCard = forwardRef<HTMLDivElement, WaterCardProps>(
+  (props, ref) => {
+    return <CardTemplate {...props} ref={ref} />
+  }
+)
+
+WaterCard.displayName = 'WaterCard'
+
+export const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   if (isPropsCropCardProps(props)) {
-    return <CropCard {...props} />
+    return <CropCard {...props} ref={ref} />
   }
 
   if (isPropsWaterCardProps(props)) {
-    return <WaterCard {...props} />
+    return <WaterCard {...props} ref={ref} />
   }
 
   throw new UnimplementedError('Unexpected CardType')
-}
+})
+
+Card.displayName = 'Card'

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Box from '@mui/material/Box'
 import Paper from '@mui/material/Paper'
 import Divider from '@mui/material/Divider'
@@ -15,128 +16,136 @@ import { CardProps } from './Card'
 export const cardClassName = 'Card'
 export const cardFlipWrapperClassName = 'CardFlipWrapper'
 
-export const CardTemplate = ({
-  card,
-  children,
-  imageScale = 0.75,
-  isFlipped = false,
-  paperProps,
-  size = CardSize.MEDIUM,
-  sx = [],
-  ...props
-}: CardProps) => {
-  const theme = useTheme()
-  const imageSrc = isCardImageKey(card.id) ? cards[card.id] : ui.pixel
+export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
+  (
+    {
+      card,
+      children,
+      imageScale = 0.75,
+      isFlipped = false,
+      paperProps,
+      size = CardSize.MEDIUM,
+      sx = [],
+      ...props
+    },
+    ref
+  ) => {
+    const theme = useTheme()
+    const imageSrc = isCardImageKey(card.id) ? cards[card.id] : ui.pixel
 
-  if (imageSrc === ui.pixel) {
-    console.error(`Card ID ${card.id} does not have an image configured`)
-  }
+    if (imageSrc === ui.pixel) {
+      console.error(`Card ID ${card.id} does not have an image configured`)
+    }
 
-  return (
-    <Box
-      className={cardClassName}
-      sx={[
-        {
-          perspective: '1000px',
-          height: CARD_DIMENSIONS[size].height,
-          width: CARD_DIMENSIONS[size].width,
-        },
-        ...(Array.isArray(sx) ? sx : [sx]),
-      ]}
-      {...props}
-    >
+    return (
       <Box
-        className={cardFlipWrapperClassName}
+        ref={ref}
+        className={cardClassName}
         sx={[
           {
+            perspective: '1000px',
             height: CARD_DIMENSIONS[size].height,
-            position: 'relative',
-            transformStyle: 'preserve-3d',
-            transition: theme.transitions.create(['transform']),
             width: CARD_DIMENSIONS[size].width,
-            ...(isFlipped && {
-              transform: 'rotateY(180deg)',
-            }),
           },
+          ...(Array.isArray(sx) ? sx : [sx]),
         ]}
+        {...props}
       >
-        <Paper
-          {...paperProps}
+        <Box
+          className={cardFlipWrapperClassName}
           sx={[
             {
-              backfaceVisibility: 'hidden',
-              background:
-                theme.palette.mode === 'light'
-                  ? darken(theme.palette.background.paper, 0.05)
-                  : lighten(theme.palette.background.paper, 0.15),
-              display: 'flex',
-              flexDirection: 'column',
-              height: 1,
-              p: theme.spacing(1),
-              position: 'absolute',
-              width: 1,
+              height: CARD_DIMENSIONS[size].height,
+              position: 'relative',
+              transformStyle: 'preserve-3d',
+              transition: theme.transitions.create(['transform']),
+              width: CARD_DIMENSIONS[size].width,
+              ...(isFlipped && {
+                transform: 'rotateY(180deg)',
+              }),
             },
           ]}
         >
-          <Typography
-            variant="overline"
-            sx={{ fontWeight: theme.typography.fontWeightBold }}
+          <Paper
+            {...paperProps}
+            sx={[
+              {
+                backfaceVisibility: 'hidden',
+                background:
+                  theme.palette.mode === 'light'
+                    ? darken(theme.palette.background.paper, 0.05)
+                    : lighten(theme.palette.background.paper, 0.15),
+                display: 'flex',
+                flexDirection: 'column',
+                height: 1,
+                p: theme.spacing(1),
+                position: 'absolute',
+                width: 1,
+              },
+            ]}
           >
-            {card.name}
-          </Typography>
-          <Box
-            sx={{
-              height: '50%',
-              display: 'flex',
-              background: theme.palette.common.white,
-              backgroundImage: `url(${ui.dirt})`,
-              backgroundSize: '100%',
-              backgroundRepeat: 'repeat',
-              borderColor: theme.palette.divider,
-              borderRadius: `${theme.shape.borderRadius}px`,
-              borderWidth: 1,
-              borderStyle: 'solid',
-              imageRendering: 'pixelated',
-            }}
-          >
-            <Image
-              src={imageSrc}
-              alt={card.name}
+            <Typography
+              variant="overline"
+              sx={{ fontWeight: theme.typography.fontWeightBold }}
+            >
+              {card.name}
+            </Typography>
+            <Box
               sx={{
-                height: `${100 * imageScale}%`,
-                p: 0,
-                m: 'auto',
+                height: '50%',
+                display: 'flex',
+                background: theme.palette.common.white,
+                backgroundImage: `url(${ui.dirt})`,
+                backgroundSize: '100%',
+                backgroundRepeat: 'repeat',
+                borderColor: theme.palette.divider,
+                borderRadius: `${theme.shape.borderRadius}px`,
+                borderWidth: 1,
+                borderStyle: 'solid',
                 imageRendering: 'pixelated',
-                filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
               }}
-            />
-          </Box>
-          <Divider sx={{ my: theme.spacing(1) }} />
-          <Box sx={{ height: '50%' }}>{children}</Box>
-        </Paper>
-        <Paper
-          {...paperProps}
-          sx={{
-            alignItems: 'center',
-            backfaceVisibility: 'hidden',
-            display: 'flex',
-            height: 1,
-            position: 'absolute',
-            textAlign: 'center',
-            transform: 'rotateY(180deg)',
-            width: 1,
-          }}
-        >
-          <Typography
-            variant="h2"
+            >
+              <Image
+                src={imageSrc}
+                alt={card.name}
+                sx={{
+                  height: `${100 * imageScale}%`,
+                  p: 0,
+                  m: 'auto',
+                  imageRendering: 'pixelated',
+                  filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
+                }}
+              />
+            </Box>
+            <Divider sx={{ my: theme.spacing(1) }} />
+            <Box sx={{ height: '50%' }}>{children}</Box>
+          </Paper>
+          <Paper
+            {...paperProps}
             sx={{
-              ...theme.typography.h4,
+              alignItems: 'center',
+              backfaceVisibility: 'hidden',
+              display: 'flex',
+              height: 1,
+              position: 'absolute',
+              textAlign: 'center',
+              transform: 'rotateY(180deg)',
+              width: 1,
             }}
           >
-            Farmhand Shuffle
-          </Typography>
-        </Paper>
+            <Typography
+              variant="h2"
+              sx={{
+                ...theme.typography.h4,
+              }}
+            >
+              Farmhand Shuffle
+            </Typography>
+          </Paper>
+        </Box>
       </Box>
-    </Box>
-  )
-}
+    )
+  }
+)
+
+CardTemplate.displayName = 'CardTemplate'

--- a/src/app/components/Deck/Deck.tsx
+++ b/src/app/components/Deck/Deck.tsx
@@ -1,5 +1,4 @@
 import Box, { BoxProps } from '@mui/material/Box'
-
 import useTheme from '@mui/material/styles/useTheme'
 
 import { lookup } from '../../../game/services/Lookup'

--- a/src/app/components/DiscardPile/DiscardPile.stories.ts
+++ b/src/app/components/DiscardPile/DiscardPile.stories.ts
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { stubGame } from '../../../test-utils/stubs/game'
+import { addToDiscardPile } from '../../../game/reducers/add-to-discard-pile'
+import { IGame } from '../../../game/types'
 
 import { DiscardPile } from './DiscardPile'
 
@@ -22,6 +24,13 @@ const game = stubGame()
 export const SelfDiscardPile: Story = {
   args: {
     playerId: game.sessionOwnerPlayerId,
-    game,
+    game: (() => {
+      const [player1Id] = Object.keys(game.table.players)
+
+      return ['carrot', 'pumpkin', 'pumpkin', 'water'].reduce(
+        (acc: IGame, cardId) => addToDiscardPile(acc, player1Id, cardId),
+        game
+      )
+    })(),
   },
 }

--- a/src/app/components/DiscardPile/DiscardPile.stories.ts
+++ b/src/app/components/DiscardPile/DiscardPile.stories.ts
@@ -4,7 +4,11 @@ import { stubGame } from '../../../test-utils/stubs/game'
 import { addToDiscardPile } from '../../../game/reducers/add-to-discard-pile'
 import { IGame } from '../../../game/types'
 
-import { DiscardPile } from './DiscardPile'
+import {
+  DiscardPile,
+  defaultDiscardPileCardSize,
+  defaultDiscardPileThicknessPx,
+} from './DiscardPile'
 
 const meta = {
   title: 'Farmhand Shuffle/Discard Pile',
@@ -13,22 +17,46 @@ const meta = {
     layout: 'centered',
   },
   tags: ['autodocs'],
-  argTypes: {},
+  argTypes: {
+    size: {
+      control: { type: 'number' },
+      description: 'The card size of the discard pile',
+    },
+    discardPileThicknessPx: {
+      control: { type: 'number' },
+      description: 'The thickness of the discard pile in pixels',
+    },
+  },
 } satisfies Meta<typeof DiscardPile>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 const game = stubGame()
+const [selfPlayerId, opponentPlayerId] = Object.keys(game.table.players)
 
 export const SelfDiscardPile: Story = {
   args: {
-    playerId: game.sessionOwnerPlayerId,
+    playerId: selfPlayerId,
+    size: defaultDiscardPileCardSize,
+    discardPileThicknessPx: defaultDiscardPileThicknessPx,
     game: (() => {
-      const [player1Id] = Object.keys(game.table.players)
-
       return ['carrot', 'pumpkin', 'pumpkin', 'water'].reduce(
-        (acc: IGame, cardId) => addToDiscardPile(acc, player1Id, cardId),
+        (acc: IGame, cardId) => addToDiscardPile(acc, selfPlayerId, cardId),
+        game
+      )
+    })(),
+  },
+}
+
+export const OpponentDiscardPile: Story = {
+  args: {
+    playerId: opponentPlayerId,
+    size: defaultDiscardPileCardSize,
+    discardPileThicknessPx: defaultDiscardPileThicknessPx,
+    game: (() => {
+      return ['carrot', 'pumpkin', 'pumpkin', 'water'].reduce(
+        (acc: IGame, cardId) => addToDiscardPile(acc, opponentPlayerId, cardId),
         game
       )
     })(),

--- a/src/app/components/DiscardPile/DiscardPile.tsx
+++ b/src/app/components/DiscardPile/DiscardPile.tsx
@@ -1,19 +1,69 @@
 import Box, { BoxProps } from '@mui/material/Box'
+import useTheme from '@mui/material/styles/useTheme'
 
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
+import * as cards from '../../../game/cards'
+import { CardSize } from '../../types'
+import { Card } from '../Card'
+import { CARD_DIMENSIONS } from '../../config/dimensions'
+import { isCardId } from '../../../game/types/guards'
+import { UnimplementedError } from '../../../game/services/Rules/errors'
 
 export interface DiscardPileProps extends BoxProps {
   game: IGame
   playerId: IPlayer['id']
+  size?: CardSize
+  discardPileThicknessPx?: number
 }
 
-export const DiscardPile = ({ playerId, game, ...rest }: DiscardPileProps) => {
+export const defaultDiscardPileThicknessPx = 30
+export const defaultDiscardPileCardSize = CardSize.MEDIUM
+
+export const DiscardPile = ({
+  playerId,
+  game,
+  size = defaultDiscardPileCardSize,
+  discardPileThicknessPx = defaultDiscardPileThicknessPx,
+  ...rest
+}: DiscardPileProps) => {
+  const theme = useTheme()
   const player = lookup.getPlayer(game, playerId)
 
+  const isSessionOwnerPlayer = playerId === game.sessionOwnerPlayerId
+
   return (
-    <Box {...rest} data-testid={`discard-pile_${playerId}`}>
-      {JSON.stringify(player.discardPile, null, 2)}
+    <Box
+      data-testid={`discard-pile_${playerId}`}
+      height={CARD_DIMENSIONS[size].height}
+      width={CARD_DIMENSIONS[size].width}
+      position="relative"
+      sx={{
+        ...(!isSessionOwnerPlayer && { transform: 'rotate(180deg)' }),
+      }}
+      {...rest}
+    >
+      {player.discardPile.map((cardId, idx) => {
+        if (!isCardId(cardId)) {
+          throw new UnimplementedError(`${cardId} is not a card`)
+        }
+
+        const card = cards[cardId]
+        const offset =
+          (discardPileThicknessPx / player.discardPile.length) * idx
+
+        return (
+          <Card
+            key={`${cardId}_${idx}`}
+            card={card}
+            position="absolute"
+            sx={{
+              transform: `translateX(${offset}px)`,
+              transition: theme.transitions.create(['transform']),
+            }}
+          />
+        )
+      })}
     </Box>
   )
 }

--- a/src/app/components/DiscardPile/DiscardPile.tsx
+++ b/src/app/components/DiscardPile/DiscardPile.tsx
@@ -1,6 +1,8 @@
 import Box, { BoxProps } from '@mui/material/Box'
 import useTheme from '@mui/material/styles/useTheme'
 
+import Tooltip from '@mui/material/Tooltip'
+
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
 import * as cards from '../../../game/cards'
@@ -53,15 +55,21 @@ export const DiscardPile = ({
           (discardPileThicknessPx / player.discardPile.length) * idx
 
         return (
-          <Card
+          <Tooltip
             key={`${cardId}_${idx}`}
-            card={card}
-            position="absolute"
-            sx={{
-              transform: `translateX(${offset}px)`,
-              transition: theme.transitions.create(['transform']),
-            }}
-          />
+            title={card.name}
+            placement="top"
+            arrow
+          >
+            <Card
+              card={card}
+              position="absolute"
+              sx={{
+                transform: `translateX(${offset}px)`,
+                transition: theme.transitions.create(['transform']),
+              }}
+            />
+          </Tooltip>
         )
       })}
     </Box>

--- a/src/app/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/app/components/PlayedCrop/PlayedCrop.tsx
@@ -20,7 +20,7 @@ export const unfilledWaterIndicatorOpacity = 0.25
 
 export const PlayedCrop = ({
   isInBackground,
-  cropCardProps,
+  cropCardProps: { ref, ...cropCardProps },
   ...props
 }: PlayedCropProps) => {
   const { card, playedCrop, size = CardSize.MEDIUM } = cropCardProps


### PR DESCRIPTION
### What this PR does

Implement the Discard Pile component.

### How this change can be validated

Make sure the tests pass and that the cards in the Discard Pile have tooltips that present their cards' name.

### Additional information

- https://farmhand-shuffle-git-feat-514f04-jeremy-kahns-projects-98e6f140.vercel.app/storybook/?path=%2Fstory%2Ffarmhand-shuffle-discard-pile--self-discard-pile

![Screenshot of the Discard Pile component](https://github.com/user-attachments/assets/7cd6d681-a265-4fa6-8e2a-d8ff50619af9)
