### PR TITLE
refactor(eslint): Use data immutably

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,15 @@ export default [
   { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
   pluginReact.configs.flat.recommended,
   importPlugin.flatConfigs.typescript,
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import pluginJs from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import pluginReact from 'eslint-plugin-react'
 import importPlugin from 'eslint-plugin-import'
+import functionalPlugin from 'eslint-plugin-functional'
 
 export default [
   { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
@@ -19,6 +20,7 @@ export default [
   },
   pluginReact.configs.flat.recommended,
   importPlugin.flatConfigs.typescript,
+  functionalPlugin.configs.off,
   {
     plugins: {
       import: importPlugin,
@@ -51,6 +53,7 @@ export default [
           'newlines-between': 'always-and-inside-groups',
         },
       ],
+      'functional/immutable-data': ['error'],
     },
     ignores: ['dist'],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@types/uuid": "^9.0.2",
         "@vitest/coverage-v8": "^2.0.5",
         "eslint": "^9.13.0",
+        "eslint-plugin-functional": "^7.1.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react": "^7.37.2",
         "globals": "^15.11.0",
@@ -10084,6 +10085,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.3.tgz",
+      "integrity": "sha512-qCSH6I0INPxd9Y1VtAiLpnYvz5O//6rCfJXKk0z66Up9/VOSr+1yS8XSKA5IWRxjocFGlzPyaZYe+jxq7OOLtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/default-browser-id": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
@@ -10944,6 +10954,54 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-functional": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-functional/-/eslint-plugin-functional-7.1.0.tgz",
+      "integrity": "sha512-eu7lVAF9dDTw2xzlsLDvJRXx9t4g/S/pmCSdGx2oFmibmkz2LMoPDu7B+UA9CV/RzvNr4wWd4apc71nMAazdKQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/eslint-plugin-functional"
+        }
+      ],
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.10.0",
+        "deepmerge-ts": "^7.1.3",
+        "escape-string-regexp": "^5.0.0",
+        "is-immutable-type": "^5.0.0",
+        "ts-api-utils": "^1.3.0",
+        "ts-declaration-location": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=v18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0",
+        "typescript": ">=4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-functional/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -12684,6 +12742,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-immutable-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-5.0.0.tgz",
+      "integrity": "sha512-mcvHasqbRBWJznuPqqHRKiJgYAz60sZ0mvO3bN70JbkuK7ksfmgc489aKZYxMEjIbRvyOseaTjaRZLRF/xFeRA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/type-utils": "^8.0.0",
+        "ts-api-utils": "^1.3.0",
+        "ts-declaration-location": "^1.0.4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": ">=4.7.4"
       }
     },
     "node_modules/is-interactive": {
@@ -17816,6 +17889,42 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-declaration-location": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.4.tgz",
+      "integrity": "sha512-r4JoxYhKULbZuH81Pjrp9OEG5St7XWk7zXwGkLKhmVcjiBVHTJXV5wK6dEa9JKW5QGSTW6b1lOjxAKp8R1SQhg==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
+      }
+    },
+    "node_modules/ts-declaration-location/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/ts-declaration-location/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ts-dedent": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/uuid": "^9.0.2",
     "@vitest/coverage-v8": "^2.0.5",
     "eslint": "^9.13.0",
+    "eslint-plugin-functional": "^7.1.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.2",
     "globals": "^15.11.0",

--- a/src/__mocks__/lodash.shuffle.ts
+++ b/src/__mocks__/lodash.shuffle.ts
@@ -3,6 +3,7 @@
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const shuffle = (arr: any[]) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return arr
 }
 

--- a/src/app/components/Card/Card.tsx
+++ b/src/app/components/Card/Card.tsx
@@ -42,7 +42,7 @@ const isPropsWaterCardProps = (props: CardProps): props is WaterCardProps => {
 }
 
 export const CropCard = forwardRef<HTMLDivElement, CropCardProps>(
-  ({ playedCrop, ...props }, ref) => {
+  function CropCard({ playedCrop, ...props }, ref) {
     return (
       <CardTemplate {...props} ref={ref}>
         {isCrop(props.card) ? (
@@ -53,17 +53,16 @@ export const CropCard = forwardRef<HTMLDivElement, CropCardProps>(
   }
 )
 
-CropCard.displayName = 'CropCard'
-
 export const WaterCard = forwardRef<HTMLDivElement, WaterCardProps>(
-  (props, ref) => {
+  function WaterCard(props, ref) {
     return <CardTemplate {...props} ref={ref} />
   }
 )
 
-WaterCard.displayName = 'WaterCard'
-
-export const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  props,
+  ref
+) {
   if (isPropsCropCardProps(props)) {
     return <CropCard {...props} ref={ref} />
   }
@@ -74,5 +73,3 @@ export const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
 
   throw new UnimplementedError('Unexpected CardType')
 })
-
-Card.displayName = 'Card'

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -18,7 +18,7 @@ export const cardClassName = 'Card'
 export const cardFlipWrapperClassName = 'CardFlipWrapper'
 
 export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
-  (
+  function CardTemplate(
     {
       card,
       children,
@@ -30,7 +30,7 @@ export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
       ...props
     },
     ref
-  ) => {
+  ) {
     const theme = useTheme()
     const imageSrc = isCardImageKey(card.id) ? cards[card.id] : ui.pixel
 
@@ -148,5 +148,3 @@ export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
     )
   }
 )
-
-CardTemplate.displayName = 'CardTemplate'

--- a/src/app/components/Card/CardTemplate.tsx
+++ b/src/app/components/Card/CardTemplate.tsx
@@ -10,6 +10,7 @@ import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { cards, isCardImageKey, ui } from '../../img'
 import { Image } from '../Image'
 import { CardSize } from '../../types'
+import { isSxArray } from '../../type-guards'
 
 import { CardProps } from './Card'
 
@@ -47,7 +48,7 @@ export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
             height: CARD_DIMENSIONS[size].height,
             width: CARD_DIMENSIONS[size].width,
           },
-          ...(Array.isArray(sx) ? sx : [sx]),
+          ...(isSxArray(sx) ? sx : [sx]),
         ]}
         {...props}
       >

--- a/src/app/components/Deck/Deck.tsx
+++ b/src/app/components/Deck/Deck.tsx
@@ -12,6 +12,7 @@ import { UnimplementedError } from '../../../game/services/Rules/errors'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { CardSize } from '../../types'
 import { useSelectedCardPosition } from '../../hooks/useSelectedCardPosition'
+import { isSxArray } from '../../type-guards'
 
 export interface DeckProps extends BoxProps {
   game: IGame
@@ -32,7 +33,7 @@ export const Deck = ({
   playerId,
   deckThicknessPx = defaultDeckThicknessPx,
   cardSize = defaultDeckCardSize,
-  sx,
+  sx = [],
   ...rest
 }: DeckProps) => {
   const { containerRef, selectedCardSxProps } = useSelectedCardPosition({
@@ -55,7 +56,7 @@ export const Deck = ({
         {
           ...(!isSessionOwnerPlayer && { transform: 'rotate(180deg)' }),
         },
-        ...(Array.isArray(sx) ? sx : [sx]),
+        ...(isSxArray(sx) ? sx : [sx]),
       ]}
       {...rest}
     >

--- a/src/app/components/Field/Field.test.tsx
+++ b/src/app/components/Field/Field.test.tsx
@@ -55,7 +55,7 @@ describe('Field', () => {
     }
   })
 
-  test('renders crop cards for opponent upside-down', async () => {
+  test('renders crop cards for opponent upside-down', () => {
     render(<StubField playerId={opponentPlayerId} />)
 
     const playedCrops = screen.getAllByLabelText(unselectedCardLabel)
@@ -127,8 +127,8 @@ describe('Field', () => {
       screen.getAllByLabelText(unselectedCardLabel)
     await userEvent.click(playedCrop1)
 
-    await waitFor(() => {
-      userEvent.keyboard('{Tab}')
+    await waitFor(async () => {
+      await userEvent.keyboard('{Tab}')
     })
 
     const { transform: card1Transform } = getComputedStyle(playedCrop1)
@@ -149,8 +149,8 @@ describe('Field', () => {
 
     await userEvent.click(playedCrop1)
 
-    await waitFor(() => {
-      userEvent.keyboard('{Escape}')
+    await waitFor(async () => {
+      await userEvent.keyboard('{Escape}')
     })
 
     const { transform: card1Transform } = getComputedStyle(playedCrop1)

--- a/src/app/components/Hand/Hand.test.tsx
+++ b/src/app/components/Hand/Hand.test.tsx
@@ -85,8 +85,8 @@ describe('Hand', () => {
 
     await userEvent.click(card1!)
 
-    await waitFor(() => {
-      userEvent.keyboard('{Tab}')
+    await waitFor(async () => {
+      await userEvent.keyboard('{Tab}')
     })
 
     const { transform: card1Transform } = getComputedStyle(card1!)
@@ -109,8 +109,8 @@ describe('Hand', () => {
 
     await userEvent.click(card1!)
 
-    await waitFor(() => {
-      userEvent.keyboard('{Escape}')
+    await waitFor(async () => {
+      await userEvent.keyboard('{Escape}')
     })
 
     const { transform: card1Transform } = getComputedStyle(card1!)

--- a/src/app/components/Hand/Hand.tsx
+++ b/src/app/components/Hand/Hand.tsx
@@ -13,6 +13,7 @@ import { SELECTED_CARD_ELEVATION } from '../../../game/config'
 import { useSelectedCardPosition } from '../../hooks/useSelectedCardPosition'
 import { CardSize } from '../../types'
 import { Card } from '../Card'
+import { isSxArray } from '../../type-guards'
 
 const deselectedIdx = -1
 const foregroundCardScale = 1
@@ -96,7 +97,7 @@ export const Hand = ({
           position: 'relative',
           minHeight: CARD_DIMENSIONS[cardSize].height,
         },
-        ...(Array.isArray(sx) ? sx : [sx]),
+        ...(isSxArray(sx) ? sx : [sx]),
       ]}
       onKeyDown={handleKeyDown}
       onBlur={handleBlur}

--- a/src/app/hooks/useSelectedCardPosition.test.ts
+++ b/src/app/hooks/useSelectedCardPosition.test.ts
@@ -64,6 +64,7 @@ describe('useSelectedCardPosition', () => {
       () => mockBoundingClientRect
     )
 
+    // eslint-disable-next-line functional/immutable-data
     result.current.containerRef.current = div
 
     // Trigger resize event

--- a/src/app/hooks/useSelectedCardPosition.test.ts
+++ b/src/app/hooks/useSelectedCardPosition.test.ts
@@ -39,8 +39,11 @@ describe('useSelectedCardPosition', () => {
     expect(result.current.containerRef).toBeDefined()
     expect(result.current.selectedCardSxProps).toEqual(
       expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         boxShadow: expect.any(String),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         transform: expect.stringContaining('translate'),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         zIndex: expect.any(Number),
       })
     )

--- a/src/app/type-guards.ts
+++ b/src/app/type-guards.ts
@@ -3,7 +3,7 @@ import { Theme } from '@mui/material/styles/createTheme'
 import { SystemStyleObject } from '@mui/system/styleFunctionSx/styleFunctionSx'
 
 // NOTE: This is a workaround for unhelpful TypeScript behavior that conflicts
-// with MUI best practices.
+// with MUI idioms.
 // See: https://github.com/mui/material-ui/issues/37730#issuecomment-2218304523
 export const isSxArray = (
   sx: SxProps<Theme>

--- a/src/app/type-guards.ts
+++ b/src/app/type-guards.ts
@@ -1,0 +1,16 @@
+import { SxProps } from '@mui/material/styles'
+import { Theme } from '@mui/material/styles/createTheme'
+import { SystemStyleObject } from '@mui/system/styleFunctionSx/styleFunctionSx'
+
+// NOTE: This is a workaround for unhelpful TypeScript behavior that conflicts
+// with MUI best practices.
+// See: https://github.com/mui/material-ui/issues/37730#issuecomment-2218304523
+export const isSxArray = (
+  sx: SxProps<Theme>
+): sx is ReadonlyArray<
+  | boolean
+  | SystemStyleObject<Theme>
+  | ((theme: Theme) => SystemStyleObject<Theme>)
+> => {
+  return Array.isArray(sx)
+}

--- a/src/game/cards/crops/handlePlayFromHand.test.ts
+++ b/src/game/cards/crops/handlePlayFromHand.test.ts
@@ -33,7 +33,7 @@ describe('handlePlayFromHand', () => {
     const [player1Id] = Object.keys(game.table.players)
     const newGame = updatePlayer(game, player1Id, { hand: [water.id] })
 
-    expect(async () => {
+    await expect(async () => {
       await handlePlayFromHand(newGame, interactionHandlers, player1Id, 0)
     }).rejects.toThrow(InvalidCardError)
   })

--- a/src/game/cards/crops/handlePlayFromHand.ts
+++ b/src/game/cards/crops/handlePlayFromHand.ts
@@ -11,6 +11,7 @@ export const handlePlayFromHand = async (
   _interactionHandlers: InteractionHandlers,
   playerId: IPlayer['id'],
   cardIdx: number
+  // eslint-disable-next-line @typescript-eslint/require-await
 ) => {
   const card = lookup.getCardFromHand(game, playerId, cardIdx)
 

--- a/src/game/cards/water/water.test.ts
+++ b/src/game/cards/water/water.test.ts
@@ -33,14 +33,14 @@ describe('water', () => {
     test('throws an error when the player cancels selection', async () => {
       vitest
         .spyOn(interactionHandlers, 'selectCropFromField')
-        .mockImplementation(async () => {
-          throw new PlayerAbortError()
+        .mockImplementation(() => {
+          return Promise.reject(new PlayerAbortError())
         })
 
       const playedCrop = factory.buildPlayedCrop(carrot)
       const newGame = updateField(game, player1Id, { crops: [playedCrop] })
 
-      expect(async () => {
+      await expect(async () => {
         await water.onPlayFromHand(newGame, interactionHandlers, player1Id, 0)
       }).rejects.toThrow(PlayerAbortError)
     })
@@ -50,7 +50,7 @@ describe('water', () => {
         .spyOn(interactionHandlers, 'selectCropFromField')
         .mockReturnValue(Promise.resolve(0))
 
-      expect(async () => {
+      await expect(async () => {
         await water.onPlayFromHand(game, interactionHandlers, player1Id, 0)
       }).rejects.toThrow(FieldEmptyError)
     })

--- a/src/game/reducers/draw-card/index.test.ts
+++ b/src/game/reducers/draw-card/index.test.ts
@@ -3,7 +3,7 @@ import shuffle from 'lodash.shuffle'
 
 import { stubGame } from '../../../test-utils/stubs/game'
 import { carrot, pumpkin, water } from '../../cards'
-import { IGame, IPlayer } from '../../types'
+import { ICard, IGame, IPlayer } from '../../types'
 import { updatePlayer } from '../update-player'
 
 import { drawCard } from '.'
@@ -14,7 +14,9 @@ vitest.mock('lodash.shuffle', () => ({
 }))
 
 beforeEach(() => {
-  ;(shuffle as unknown as MockInstance).mockImplementation(arr => arr)
+  ;(shuffle as unknown as MockInstance).mockImplementation(
+    (arr: ICard[]) => arr
+  )
 })
 
 describe('drawCard', () => {

--- a/src/game/reducers/draw-card/index.ts
+++ b/src/game/reducers/draw-card/index.ts
@@ -8,7 +8,9 @@ export const drawCard = (game: IGame, playerId: IPlayer['id'], howMany = 1) => {
   let newDeck = [...game.table.players[playerId].deck]
   let newDiscardPile = [...game.table.players[playerId].discardPile]
 
-  const drawnCards = newDeck.splice(0, howMany)
+  const drawnCards = newDeck.slice(0, howMany)
+  newDeck = newDeck.slice(howMany)
+
   newHand = [...newHand, ...drawnCards]
 
   if (newDeck.length === 0) {

--- a/src/game/reducers/move-from-hand-to-discard-pile/index.test.ts
+++ b/src/game/reducers/move-from-hand-to-discard-pile/index.test.ts
@@ -8,6 +8,7 @@ describe('moveFromHandToDiscardPile', () => {
     const game = stubGame()
     const [player1Id] = Object.keys(game.table.players)
 
+    // eslint-disable-next-line functional/immutable-data
     game.table.players[player1Id].hand[0] = carrot.id
     const newGame = moveFromHandToDiscardPile(game, player1Id, 0)
 

--- a/src/game/reducers/shuffle-deck/index.test.ts
+++ b/src/game/reducers/shuffle-deck/index.test.ts
@@ -2,6 +2,7 @@ import { MockInstance } from 'vitest'
 import shuffle from 'lodash.shuffle'
 
 import { stubGame } from '../../../test-utils/stubs/game'
+import { ICard } from '../../types'
 
 import { shuffleDeck } from '.'
 
@@ -11,7 +12,9 @@ vitest.mock('lodash.shuffle', () => ({
 }))
 
 beforeEach(() => {
-  ;(shuffle as unknown as MockInstance).mockImplementation(arr => arr)
+  ;(shuffle as unknown as MockInstance).mockImplementation(
+    (arr: ICard[]) => arr
+  )
 })
 
 describe('shuffleDeck', () => {

--- a/src/game/reducers/update-played-crop/index.ts
+++ b/src/game/reducers/update-played-crop/index.ts
@@ -16,8 +16,11 @@ export const updatePlayedCrop = (
     )
   }
 
-  const newCrops = crops.slice()
-  newCrops[cropIdx] = { ...playedCrop, ...newPlayedCropProperties }
+  const newCrops = [
+    ...crops.slice(0, cropIdx - 1),
+    { ...playedCrop, ...newPlayedCropProperties },
+    ...crops.slice(cropIdx + 1),
+  ]
 
   game = updateField(game, playerId, {
     crops: newCrops,

--- a/src/game/reducers/update-player/index.ts
+++ b/src/game/reducers/update-player/index.ts
@@ -1,18 +1,20 @@
-import cloneDeep from 'lodash.clonedeep'
-
 import { IGame, IPlayer } from '../../types'
+import { updateTable } from '../update-table'
 
 export const updatePlayer = (
   game: IGame,
   playerId: IPlayer['id'],
   newPlayerProperties: Partial<IPlayer>
 ): IGame => {
-  const newGame = cloneDeep(game)
+  game = updateTable(game, {
+    players: {
+      ...game.table.players,
+      [playerId]: {
+        ...game.table.players[playerId],
+        ...newPlayerProperties,
+      },
+    },
+  })
 
-  newGame.table.players[playerId] = {
-    ...game.table.players[playerId],
-    ...newPlayerProperties,
-  }
-
-  return newGame
+  return game
 }

--- a/src/game/services/Lookup/index.test.ts
+++ b/src/game/services/Lookup/index.test.ts
@@ -18,6 +18,7 @@ describe('Lookup', () => {
       mutatedGame = stubGame()
       player1Id = Object.keys(mutatedGame.table.players)[0]
 
+      // eslint-disable-next-line functional/immutable-data
       mutatedGame.table.players[player1Id].hand[0] = carrot.id
     })
 

--- a/src/game/services/Rules/index.test.ts
+++ b/src/game/services/Rules/index.test.ts
@@ -41,6 +41,7 @@ beforeEach(() => {
 
 // Make player2's deck slightly different from player1's to prevent false
 // positives.
+// eslint-disable-next-line functional/immutable-data
 player2.deck[DECK_SIZE - 1] = pumpkin.id
 
 describe('Rules', () => {
@@ -163,6 +164,7 @@ describe('Rules', () => {
       game = rules.processGameStart([player1, player2])
       player1Id = Object.keys(game.table.players)[0]
 
+      // eslint-disable-next-line functional/immutable-data
       game.table.players[player1Id].hand[0] = carrot.id
     })
 

--- a/src/game/services/Rules/index.test.ts
+++ b/src/game/services/Rules/index.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../config'
 import { isGame } from '../../types/guards'
 import { handlePlayFromHand as mockCropHandlePlayFromHand } from '../../cards/crops/handlePlayFromHand'
-import { IGame, IPlayer } from '../../types'
+import { ICard, IGame, IPlayer } from '../../types'
 import { updatePlayer } from '../../reducers/update-player'
 import { randomNumber } from '../../../services/RandomNumber'
 import { carrot, pumpkin } from '../../cards'
@@ -34,7 +34,9 @@ vitest.mock('lodash.shuffle', () => ({
 }))
 
 beforeEach(() => {
-  ;(shuffle as unknown as MockInstance).mockImplementation(arr => arr)
+  ;(shuffle as unknown as MockInstance).mockImplementation(
+    (arr: ICard[]) => arr
+  )
 })
 
 // Make player2's deck slightly different from player1's to prevent false
@@ -154,8 +156,8 @@ describe('Rules', () => {
         mockCropHandlePlayFromHand as unknown as MockInstance<
           typeof mockCropHandlePlayFromHand
         >
-      ).mockImplementation(async (game: IGame) => {
-        return game
+      ).mockImplementation((game: IGame) => {
+        return Promise.resolve(game)
       })
 
       game = rules.processGameStart([player1, player2])

--- a/src/game/services/Rules/index.ts
+++ b/src/game/services/Rules/index.ts
@@ -27,7 +27,9 @@ export class RulesService {
         funds: Math.floor(game.table.communityFund / playerSeeds.length),
       })
 
-      game.table.players[player.id] = player
+      game = updateTable(game, {
+        players: { ...game.table.players, [player.id]: player },
+      })
       game = shuffleDeck(game, player.id)
       game = drawCard(game, player.id, INITIAL_HAND_SIZE)
     }

--- a/src/test-utils/stubs/deck.ts
+++ b/src/test-utils/stubs/deck.ts
@@ -1,3 +1,4 @@
+/* eslint-disable functional/immutable-data */
 import { carrot, pumpkin } from '../../game/cards'
 import { water } from '../../game/cards/water'
 import { DECK_SIZE } from '../../game/config'

--- a/src/test-utils/stubs/deck.ts
+++ b/src/test-utils/stubs/deck.ts
@@ -1,10 +1,10 @@
 import { carrot, pumpkin } from '../../game/cards'
 import { water } from '../../game/cards/water'
 import { DECK_SIZE } from '../../game/config'
-import { ICrop } from '../../game/types'
+import { ICard, ICrop } from '../../game/types'
 
 export const stubDeck = (): ICrop['id'][] => {
-  const deck = new Array(DECK_SIZE)
+  const deck = new Array<ICard>(DECK_SIZE)
 
   deck.fill(water)
 

--- a/src/test-utils/stubs/interactionHandlers.ts
+++ b/src/test-utils/stubs/interactionHandlers.ts
@@ -2,6 +2,6 @@ import { InteractionHandlers } from '../../game/services/Rules/InteractionHandle
 
 export const stubInteractionHandlers = (): InteractionHandlers => {
   return {
-    selectCropFromField: async () => 0,
+    selectCropFromField: () => Promise.resolve(0),
   }
 }


### PR DESCRIPTION
### What this PR does

This PR enables the [`functional/immutable-data`](https://github.com/eslint-functional/eslint-plugin-functional/blob/main/docs/rules/immutable-data.md) ESlint rule and updates the application code accordingly. This is done to avoid bugs that result from data mutations.

### How this change can be validated

Validate that the test pass.

### Additional information

I chose to disable the rule as necessary in tests. This is because it seems worth keeping test code simple and obvious rather than adding complexity for the sake of avoiding data mutations.