### PR TITLE
fix(ui): Improve card playing animation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import globals from 'globals'
 import pluginJs from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import pluginReact from 'eslint-plugin-react'
+import pluginReactHooks from 'eslint-plugin-react-hooks'
 import importPlugin from 'eslint-plugin-import'
 import functionalPlugin from 'eslint-plugin-functional'
 
@@ -19,6 +20,14 @@ export default [
     },
   },
   pluginReact.configs.flat.recommended,
+  // TODO: Simplify when https://github.com/facebook/react/issues/28313 is
+  // resolved and released
+  {
+    plugins: {
+      'react-hooks': pluginReactHooks,
+    },
+    rules: { ...pluginReactHooks.configs.recommended.rules },
+  },
   importPlugin.flatConfigs.typescript,
   functionalPlugin.configs.off,
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "eslint-plugin-functional": "^7.1.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react": "^7.37.2",
+        "eslint-plugin-react-hooks": "^5.1.0",
         "globals": "^15.11.0",
         "husky": "^8.0.3",
         "prettier": "^2.8.8",
@@ -7207,6 +7208,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
+      "integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-functional": "^7.1.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.2",
+    "eslint-plugin-react-hooks": "^5.1.0",
     "globals": "^15.11.0",
     "husky": "^8.0.3",
     "prettier": "^2.8.8",

--- a/src/lib/hooks/useRejectingTimeout.test.ts
+++ b/src/lib/hooks/useRejectingTimeout.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { useRejectingTimeout } from './useRejectingTimeout'
+
+beforeEach(() => {
+  vi.useFakeTimers() // Mock timers for testing
+})
+
+describe('useRejectingTimeout', () => {
+  it('resolves the promise after a delay if not rejected', async () => {
+    const { result } = renderHook(() => useRejectingTimeout())
+
+    const { setRejectingTimeout } = result.current
+
+    const resolveSpy = vi.fn()
+    setRejectingTimeout(100)
+      .then(resolveSpy)
+      .catch(() => {})
+
+    // Ensure timers are advanced to resolve the promise
+    vi.advanceTimersByTime(100)
+    vi.useRealTimers()
+
+    await waitFor(() => {
+      expect(resolveSpy).toHaveBeenCalled()
+    })
+  })
+
+  it('rejects the promise if component unmounts before timeout', async () => {
+    const { result, unmount } = renderHook(() => useRejectingTimeout())
+
+    const { setRejectingTimeout } = result.current
+
+    const rejectSpy = vi.fn()
+    setRejectingTimeout(100)
+      .then(() => {})
+      .catch(rejectSpy)
+
+    // Ensure timers are advanced to resolve the promise
+    vi.advanceTimersByTime(50)
+    vi.useRealTimers()
+
+    unmount()
+    await waitFor(() => {
+      expect(rejectSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/lib/hooks/useRejectingTimeout.ts
+++ b/src/lib/hooks/useRejectingTimeout.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react'
+
+// NOTE: Provides await-able timeouts that get rejected when the component
+// unmounts. Useful for component animations that need to be cancelled if the
+// component unmounts before they complete (use it in a try/catch).
+export const useRejectingTimeout = () => {
+  const timeoutPool = useRef(new Map<NodeJS.Timeout, () => void>())
+
+  useEffect(() => {
+    const { current } = timeoutPool
+    return () => {
+      current.forEach(reject => {
+        reject()
+      })
+    }
+  }, [])
+
+  const setRejectingTimeout = (delay: number) => {
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        timeoutPool.current.delete(timeout)
+
+        resolve()
+      }, delay)
+
+      timeoutPool.current.set(timeout, reject)
+    })
+  }
+
+  return { setRejectingTimeout }
+}

--- a/src/lib/sleep.ts
+++ b/src/lib/sleep.ts
@@ -1,0 +1,4 @@
+export const sleep = (milliseconds: number): Promise<void> =>
+  new Promise<void>(res => {
+    setTimeout(res, milliseconds)
+  })

--- a/src/lib/sleep.ts
+++ b/src/lib/sleep.ts
@@ -1,4 +1,0 @@
-export const sleep = (milliseconds: number): Promise<void> =>
-  new Promise<void>(res => {
-    setTimeout(res, milliseconds)
-  })

--- a/src/ui/components/Card/Card.tsx
+++ b/src/ui/components/Card/Card.tsx
@@ -23,6 +23,7 @@ export enum CardFocusMode {
 export interface BaseCardProps extends BoxProps {
   card: ICard
   cardIdx: number
+  disableEnterAnimation?: boolean
   playerId: string
   size?: CardSize
   imageScale?: number
@@ -38,6 +39,7 @@ export type WaterCardProps = BaseCardProps
 export type CardProps = (CropCardProps | WaterCardProps) & {
   isFlipped?: boolean
   paperProps?: Partial<Omit<PaperProps, 'sx'>>
+  onBeforePlay?: () => Promise<void>
 }
 
 const isPropsCropCardProps = (props: CardProps): props is CropCardProps => {

--- a/src/ui/components/Card/Card.tsx
+++ b/src/ui/components/Card/Card.tsx
@@ -39,6 +39,11 @@ export type WaterCardProps = BaseCardProps
 export type CardProps = (CropCardProps | WaterCardProps) & {
   isFlipped?: boolean
   paperProps?: Partial<Omit<PaperProps, 'sx'>>
+  /**
+   * Optional asynchronous operation to perform when the player plays the
+   * card and before internal card play logic is run. This could be used to
+   * perform an animation.
+   */
   onBeforePlay?: () => Promise<void>
 }
 

--- a/src/ui/components/Card/CardTemplate.tsx
+++ b/src/ui/components/Card/CardTemplate.tsx
@@ -29,6 +29,8 @@ export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
       playerId,
       children,
       cardFocusMode,
+      onBeforePlay,
+      disableEnterAnimation = false,
       imageScale = 0.75,
       isFlipped = false,
       paperProps,
@@ -49,9 +51,13 @@ export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
       console.error(`Card ID ${card.id} does not have an image configured`)
     }
 
-    const handlePlayCard = () => {
+    const handlePlayCard = async () => {
       // TODO: Handle different card types appropriately (water, tool, etc.)
       if (isCropCard(card)) {
+        if (onBeforePlay) {
+          await onBeforePlay()
+        }
+
         actorRef.send({ type: GameEvent.PLAY_CROP, cardIdx, playerId })
       }
     }
@@ -72,7 +78,7 @@ export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
           {...props}
         >
           <motion.div
-            initial={{ scale: 0 }}
+            initial={disableEnterAnimation ? false : { scale: 0 }}
             animate={{ scale: 1 }}
             style={{ originX: 0.5, originY: 0.5 }}
           >
@@ -153,7 +159,10 @@ export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
                   isCropCard(card) && (
                     <Box position="absolute" right="-100%" width={1} px={1}>
                       <Typography>
-                        <Button variant="contained" onClick={handlePlayCard}>
+                        <Button
+                          variant="contained"
+                          onClick={() => void handlePlayCard()}
+                        >
                           Play card
                         </Button>
                       </Typography>

--- a/src/ui/components/Game/Game.tsx
+++ b/src/ui/components/Game/Game.tsx
@@ -1,6 +1,6 @@
 import Container, { ContainerProps } from '@mui/material/Container'
 import useTheme from '@mui/material/styles/useTheme'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { GameEvent, GameState, IPlayerSeed } from '../../../game/types'
 import { isSxArray } from '../../type-guards'
@@ -8,6 +8,7 @@ import { Table } from '../Table'
 import { TurnControl } from '../TurnControl'
 
 import { ActorContext } from './ActorContext'
+import { InputBlockContext, InputBlockContextProps } from './InputBlockContext'
 
 export interface GameProps extends ContainerProps {
   playerSeeds: IPlayerSeed[]
@@ -26,25 +27,58 @@ const GameCore = ({
     ({ value, context: { game } }) => [value, game]
   )
 
+  const [isInputBlocked, setIsInputBlocked] = useState(false)
+
   useEffect(() => {
     if (state === GameState.UNINITIALIZED) {
       actorRef.send({ type: GameEvent.INIT, playerSeeds, userPlayerId })
     }
-  }, [state, playerSeeds, userPlayerId])
+  }, [state, playerSeeds, userPlayerId, actorRef])
+
+  const blockingOperation: InputBlockContextProps['blockingOperation'] =
+    useCallback(
+      async fn => {
+        try {
+          setIsInputBlocked(true)
+          await fn()
+        } catch (_e) {
+          // Empty
+        } finally {
+          setIsInputBlocked(false)
+        }
+      },
+      [setIsInputBlocked]
+    )
+
+  const inputBlockContextValue: InputBlockContextProps = useMemo(
+    () => ({ blockingOperation }),
+    [blockingOperation]
+  )
 
   return (
-    <Container
-      maxWidth={false}
-      data-testid="game"
-      sx={[
-        { backgroundColor: theme.palette.grey['500'], py: 3, overflow: 'auto' },
-        ...(isSxArray(sx) ? sx : [sx]),
-      ]}
-      {...rest}
-    >
-      <TurnControl game={game} />
-      <Table sx={{ pt: 4 }} game={game} />
-    </Container>
+    <InputBlockContext.Provider value={inputBlockContextValue}>
+      <Container
+        maxWidth={false}
+        data-testid="game"
+        sx={[
+          {
+            backgroundColor: theme.palette.grey['500'],
+            py: 3,
+            overflow: 'auto',
+            ...(isInputBlocked && {
+              '*': {
+                pointerEvents: 'none',
+              },
+            }),
+          },
+          ...(isSxArray(sx) ? sx : [sx]),
+        ]}
+        {...rest}
+      >
+        <TurnControl game={game} />
+        <Table sx={{ pt: 4 }} game={game} />
+      </Container>
+    </InputBlockContext.Provider>
   )
 }
 

--- a/src/ui/components/Game/InputBlockContext.tsx
+++ b/src/ui/components/Game/InputBlockContext.tsx
@@ -1,0 +1,16 @@
+import { createContext } from 'react'
+
+export interface InputBlockContextProps {
+  /**
+   * Prevents user interaction while some asynchronous operation is performed.
+   */
+  blockingOperation: (fn: () => Promise<void>) => Promise<void>
+}
+
+export const InputBlockContext = createContext<InputBlockContextProps>({
+  blockingOperation: () => {
+    throw new Error(
+      'Calling blockingOperation outside of InputBlockContext.Provider'
+    )
+  },
+})

--- a/src/ui/components/Hand/Hand.tsx
+++ b/src/ui/components/Hand/Hand.tsx
@@ -15,6 +15,7 @@ import { CardSize } from '../../types'
 import { Card, CardFocusMode } from '../Card'
 import { isSxArray } from '../../type-guards'
 import { ActorContext } from '../Game/ActorContext'
+import { sleep } from '../../../lib/sleep'
 
 const deselectedIdx = -1
 const foregroundCardScale = 1
@@ -101,6 +102,13 @@ export const Hand = ({
       width: 0,
     }
 
+  const handleBeforePlay = async () => {
+    // FIXME: Block input during animation
+    // FIXME: Abort async operation on unmount
+    resetSelectedCard()
+    await sleep(theme.transitions.duration.shortest)
+  }
+
   return (
     <Box
       {...rest}
@@ -166,6 +174,7 @@ export const Hand = ({
         return (
           <Card
             key={`${cardId}_${idx}`}
+            disableEnterAnimation
             card={card}
             cardIdx={idx}
             playerId={playerId}
@@ -182,6 +191,7 @@ export const Hand = ({
               cursor: 'pointer',
               ...(isSelected && selectedCardSxProps),
             }}
+            onBeforePlay={handleBeforePlay}
             onFocus={() => handleCardFocus(idx)}
             tabIndex={0}
             cardFocusMode={cardFocusMode}


### PR DESCRIPTION
### What this PR does

This PR improves a bad animation introduced by #23. Specifically, when the player played a card from their hand, the next card in the hand was briefly shown in the "selected" state. This is because React rendered the change faster than the CSS transition could account it. This PR changes the animation to move the card back to the player's hand before unmounting the component. It doesn't look _great_ but it at least doesn't look broken.

I welcome anyone to improve this further. This is just as far as I cared to take this. :laughing:

### How this change can be validated

- [ ] Verify that the player can successfully play a card from their hand

### Questions or concerns about this change

I hate animating things in React

### Additional information

Old version:
[Screencast of old animation](https://github.com/user-attachments/assets/f08ebd35-85fd-4def-8d27-9bd449db311b)

New version:
[Screencast of new animation](https://github.com/user-attachments/assets/cdd2573f-6502-4409-9d3c-c87455de6bc1)
