### PR TITLE
refactor(types): Address type-related TODOs

### DIFF
--- a/src/game/reducers/increment-player/index.ts
+++ b/src/game/reducers/increment-player/index.ts
@@ -7,8 +7,7 @@ export const incrementPlayer = (game: IGame) => {
 
   assertCurrentPlayer(currentPlayerId)
 
-  // TODO: Don't rely on stable key order. Consider sorting the keys.
-  const playerIds = Object.keys(game.table.players)
+  const playerIds = Object.keys(game.table.players).sort()
 
   const currentPlayerIdx = playerIds.indexOf(currentPlayerId)
   const newPlayerIdx = (currentPlayerIdx + 1) % playerIds.length

--- a/src/game/reducers/increment-player/index.ts
+++ b/src/game/reducers/increment-player/index.ts
@@ -1,17 +1,16 @@
 import { IGame } from '../../types'
+import { assertCurrentPlayer } from '../../types/guards'
 import { updateGame } from '../update-game'
 
 export const incrementPlayer = (game: IGame) => {
   const { currentPlayerId } = game
+
+  assertCurrentPlayer(currentPlayerId)
+
   // TODO: Don't rely on stable key order. Consider sorting the keys.
   const playerIds = Object.keys(game.table.players)
 
-  if (currentPlayerId === null) {
-    throw new TypeError('[TypeError] currentPlayerId must not be null')
-  }
-
   const currentPlayerIdx = playerIds.indexOf(currentPlayerId)
-
   const newPlayerIdx = (currentPlayerIdx + 1) % playerIds.length
   game = updateGame(game, { currentPlayerId: playerIds[newPlayerIdx] })
 

--- a/src/game/services/Lookup/index.ts
+++ b/src/game/services/Lookup/index.ts
@@ -1,11 +1,7 @@
 import * as cards from '../../cards'
 import { ICard, IGame, IPlayer, isCropCard } from '../../types'
-import { assertIsCardId, isCardId, isCrop } from '../../types/guards'
-import {
-  GameStateCorruptError,
-  InvalidCardError,
-  InvalidIdError,
-} from '../Rules/errors'
+import { assertIsCardId, isCrop } from '../../types/guards'
+import { InvalidCardError, InvalidIdError } from '../Rules/errors'
 
 export class LookupService {
   getCardFromHand = (
@@ -22,11 +18,7 @@ export class LookupService {
       )
     }
 
-    // NOTE: This check is not logically necessary, but it is required to
-    // prevent cards[cardId] from being implicitly cast as an any type.
-    if (!isCardId(cardId)) {
-      throw new GameStateCorruptError(`${cardId} is not a valid card ID`)
-    }
+    assertIsCardId(cardId)
 
     const card = cards[cardId]
 

--- a/src/game/services/Rules/state-machine.ts
+++ b/src/game/services/Rules/state-machine.ts
@@ -32,10 +32,7 @@ export const { createMachine } = setup({
       context: { game },
     }) {
       assertEvent(event, GameEvent.START_TURN)
-
-      if (game.currentPlayerId === null) {
-        throw new TypeError('currentPlayerId is null')
-      }
+      assertCurrentPlayer(game.currentPlayerId)
 
       return Object.values(game.table.players).every(
         player => player.field.crops.length > 0
@@ -139,11 +136,7 @@ export const machineConfig: RulesMachineConfig = {
           case GameEvent.PROMPT_PLAYER_FOR_SETUP: {
             const { currentPlayerId } = game
 
-            if (currentPlayerId === null) {
-              throw new TypeError(
-                '[TypeError] currentPlayerId must not be null'
-              )
-            }
+            assertCurrentPlayer(currentPlayerId)
 
             const currentPlayerField = game.table.players[currentPlayerId].field
 
@@ -196,9 +189,7 @@ export const machineConfig: RulesMachineConfig = {
         game: ({ event, context: { game } }) => {
           switch (event.type) {
             case GameEvent.START_TURN: {
-              if (game.currentPlayerId === null) {
-                throw new TypeError('currentPlayerId is null')
-              }
+              assertCurrentPlayer(game.currentPlayerId)
 
               game = startTurn(game, game.currentPlayerId)
 

--- a/src/game/services/Validation/index.ts
+++ b/src/game/services/Validation/index.ts
@@ -1,6 +1,6 @@
 import * as cards from '../../cards'
 import { IPlayer, isCropCard } from '../../types'
-import { isCardId } from '../../types/guards'
+import { assertIsCardId } from '../../types/guards'
 import { GameStateCorruptError } from '../Rules/errors'
 
 export class ValidationService {
@@ -10,9 +10,7 @@ export class ValidationService {
    */
   player = (player: IPlayer) => {
     const deckContainsCrop = player.deck.some(cardId => {
-      if (!isCardId(cardId)) {
-        throw new GameStateCorruptError(`${cardId} is not a valid card ID`)
-      }
+      assertIsCardId(cardId)
 
       const card = cards[cardId]
 

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -79,7 +79,6 @@ export function assertIsCardId(id: string): asserts id is keyof typeof cards {
   }
 }
 
-// TODO: Use this everywhere instead of doing the check directly
 export function assertCurrentPlayer(
   currentPlayerId: string | null
 ): asserts currentPlayerId is string {

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -73,7 +73,6 @@ export const isGame = (obj: unknown): obj is IGame => {
 
 export const isCardId = (id: string): id is keyof typeof cards => id in cards
 
-// TODO: Use this everywhere instead of isCardId + GameStateCorruptError
 export function assertIsCardId(id: string): asserts id is keyof typeof cards {
   if (!isCardId(id)) {
     throw new GameStateCorruptError(`${id} is not a valid card ID`)

--- a/src/ui/components/Deck/Deck.tsx
+++ b/src/ui/components/Deck/Deck.tsx
@@ -3,16 +3,15 @@ import useTheme from '@mui/material/styles/useTheme'
 
 import { MouseEventHandler } from 'react'
 
+import * as cards from '../../../game/cards'
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
-import * as cards from '../../../game/cards'
-import { Card } from '../Card'
-import { isCardId } from '../../../game/types/guards'
-import { UnimplementedError } from '../../../game/services/Rules/errors'
+import { assertIsCardId } from '../../../game/types/guards'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
-import { CardSize } from '../../types'
 import { useSelectedCardPosition } from '../../hooks/useSelectedCardPosition'
 import { isSxArray } from '../../type-guards'
+import { CardSize } from '../../types'
+import { Card } from '../Card'
 
 export interface DeckProps extends BoxProps {
   game: IGame
@@ -65,9 +64,7 @@ export const Deck = ({
         // artifacting (for some reason)
         const cardId = deck[deck.length - 1 - idx]
 
-        if (!isCardId(cardId)) {
-          throw new UnimplementedError(`${cardId} is not a card`)
-        }
+        assertIsCardId(cardId)
 
         const card = cards[cardId]
         const offset = (deckThicknessPx / player.deck.length) * idx

--- a/src/ui/components/DiscardPile/DiscardPile.tsx
+++ b/src/ui/components/DiscardPile/DiscardPile.tsx
@@ -1,16 +1,14 @@
 import Box, { BoxProps } from '@mui/material/Box'
 import useTheme from '@mui/material/styles/useTheme'
-
 import Tooltip from '@mui/material/Tooltip'
 
+import * as cards from '../../../game/cards'
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
-import * as cards from '../../../game/cards'
+import { assertIsCardId } from '../../../game/types/guards'
+import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { CardSize } from '../../types'
 import { Card } from '../Card'
-import { CARD_DIMENSIONS } from '../../config/dimensions'
-import { isCardId } from '../../../game/types/guards'
-import { UnimplementedError } from '../../../game/services/Rules/errors'
 
 export interface DiscardPileProps extends BoxProps {
   game: IGame
@@ -53,9 +51,7 @@ export const DiscardPile = ({
       {...rest}
     >
       {player.discardPile.map((cardId, idx) => {
-        if (!isCardId(cardId)) {
-          throw new UnimplementedError(`${cardId} is not a card`)
-        }
+        assertIsCardId(cardId)
 
         const card = cards[cardId]
         const offset =

--- a/src/ui/components/Field/Field.tsx
+++ b/src/ui/components/Field/Field.tsx
@@ -8,8 +8,7 @@ import { PlayedCrop } from '../PlayedCrop'
 import * as cards from '../../../game/cards'
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
-import { isCardId } from '../../../game/types/guards'
-import { UnimplementedError } from '../../../game/services/Rules/errors'
+import { assertIsCardId } from '../../../game/types/guards'
 import {
   SELECTED_CARD_ELEVATION,
   STANDARD_FIELD_SIZE,
@@ -132,19 +131,23 @@ export const Field = ({
         justifyContent="center"
       >
         {crops.map((playedCrop, idx) => {
-          const { id, waterCards } = playedCrop
+          const { id: cardId, waterCards } = playedCrop
 
-          if (!isCardId(id)) {
-            throw new UnimplementedError(`${id} is not a card`)
-          }
+          assertIsCardId(cardId)
 
-          const card = cards[id]
+          const card = cards[cardId]
           const isSelected = selectedCardIdx === idx
           const isInBackground =
             selectedCardIdx !== deselectedIdx && !isSelected
 
           return (
-            <Grid key={`${idx}_${id}_${waterCards}`} item xs={6} sm={4} md={2}>
+            <Grid
+              key={`${idx}_${cardId}_${waterCards}`}
+              item
+              xs={6}
+              sm={4}
+              md={2}
+            >
               <PlayedCrop
                 aria-label={
                   isSelected ? selectedCardLabel : unselectedCardLabel

--- a/src/ui/components/Hand/Hand.tsx
+++ b/src/ui/components/Hand/Hand.tsx
@@ -5,9 +5,8 @@ import React, { useContext, useEffect, useState } from 'react'
 import * as cards from '../../../game/cards'
 import { SELECTED_CARD_ELEVATION } from '../../../game/config'
 import { lookup } from '../../../game/services/Lookup'
-import { UnimplementedError } from '../../../game/services/Rules/errors'
 import { GameState, IGame, IPlayer } from '../../../game/types'
-import { isCardId } from '../../../game/types/guards'
+import { assertIsCardId } from '../../../game/types/guards'
 import { useRejectingTimeout } from '../../../lib/hooks/useRejectingTimeout'
 import { math } from '../../../services/Math'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
@@ -132,12 +131,9 @@ export const Hand = ({
       onBlur={handleBlur}
     >
       {player.hand.map((cardId, idx) => {
-        if (!isCardId(cardId)) {
-          throw new UnimplementedError(`${cardId} is not a card`)
-        }
+        assertIsCardId(cardId)
 
         const card = cards[cardId]
-
         const gapWidthTotal = gapWidthPx * player.hand.length
         const multipliedGap = math.scaleNumber(
           idx / player.hand.length,
@@ -147,7 +143,6 @@ export const Hand = ({
           gapWidthTotal
         )
         const xOffsetPx = containerWidth / 2 + multipliedGap
-
         const isSelected = selectedCardIdx === idx
 
         let cardFocusMode: undefined | CardFocusMode


### PR DESCRIPTION
### What this PR does

This is a maintenance PR that pays down some tech debt that's accrued. Specifically, it replaces a number of null checks [type assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions). The type assertions do the exact same thing, they're just a bit cleaner.

This PR also ensures a stable player order by sorting the keys that are used to increment whose turn it is. It's not strictly necessary, but it's good to have the peace of mind.

### How this change can be validated

- [ ] Verify that CI checks pass
- [ ] Verify that Storybook Game story is unchanged