### PR TITLE
fix(ui): Prevent remounting card components

### DIFF
--- a/src/game/cards/index.ts
+++ b/src/game/cards/index.ts
@@ -1,2 +1,10 @@
+import { v4 as uuid } from 'uuid'
+
+import { ICard, Instance } from '../types'
+
 export * from './crops'
 export * from './water'
+
+export const instantiate = <T = ICard>(card: T): T & Instance => {
+  return { ...card, instanceId: uuid() }
+}

--- a/src/game/reducers/add-crop-to-field/index.test.ts
+++ b/src/game/reducers/add-crop-to-field/index.test.ts
@@ -1,10 +1,10 @@
-import { stubGame } from '../../../test-utils/stubs/game'
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 import { stubField } from '../../../test-utils/stubs/field'
-import { carrot } from '../../cards'
-import { updateField } from '../update-field'
+import { stubGame } from '../../../test-utils/stubs/game'
 import { STANDARD_FIELD_SIZE } from '../../config'
 import { factory } from '../../services/Factory'
 import { FieldFullError } from '../../services/Rules/errors'
+import { updateField } from '../update-field'
 
 import { addCropToField } from '.'
 
@@ -12,7 +12,7 @@ describe('addCropToField', () => {
   test('adds crop to field', () => {
     const game = stubGame()
     const [player1Id] = Object.keys(game.table.players)
-    const playedCrop = factory.buildPlayedCrop(carrot)
+    const playedCrop = factory.buildPlayedCrop(stubCarrot)
 
     const newGame = addCropToField(game, player1Id, playedCrop)
 
@@ -22,7 +22,7 @@ describe('addCropToField', () => {
   test('throws an error if field is full', () => {
     const game = stubGame()
     const [player1Id] = Object.keys(game.table.players)
-    const playedCrop = factory.buildPlayedCrop(carrot)
+    const playedCrop = factory.buildPlayedCrop(stubCarrot)
 
     const fullField = stubField({
       crops: new Array(STANDARD_FIELD_SIZE).fill(playedCrop),

--- a/src/game/reducers/add-to-discard-pile/index.test.ts
+++ b/src/game/reducers/add-to-discard-pile/index.test.ts
@@ -1,5 +1,5 @@
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
-import { carrot } from '../../cards'
 
 import { addToDiscardPile } from '.'
 
@@ -7,8 +7,8 @@ describe('addToDiscardPile', () => {
   test("adds to a player's discard pile", () => {
     const game = stubGame()
     const [player1Id] = Object.keys(game.table.players)
-    const newGame = addToDiscardPile(game, player1Id, carrot.id)
+    const newGame = addToDiscardPile(game, player1Id, stubCarrot)
 
-    expect(newGame.table.players[player1Id].discardPile).toEqual([carrot.id])
+    expect(newGame.table.players[player1Id].discardPile).toEqual([stubCarrot])
   })
 })

--- a/src/game/reducers/add-to-discard-pile/index.ts
+++ b/src/game/reducers/add-to-discard-pile/index.ts
@@ -1,12 +1,15 @@
-import { ICard, IGame, IPlayer } from '../../types'
+import { CardInstance, IGame, IPlayer } from '../../types'
 import { updatePlayer } from '../update-player'
 
 export const addToDiscardPile = (
   game: IGame,
   playerId: IPlayer['id'],
-  cardId: ICard['id']
+  cardInstancestance: CardInstance
 ) => {
-  const discardPile = [cardId, ...game.table.players[playerId].discardPile]
+  const discardPile = [
+    cardInstancestance,
+    ...game.table.players[playerId].discardPile,
+  ]
   game = updatePlayer(game, playerId, { discardPile })
 
   return game

--- a/src/game/reducers/draw-card/index.test.ts
+++ b/src/game/reducers/draw-card/index.test.ts
@@ -2,7 +2,7 @@ import { MockInstance } from 'vitest'
 import shuffle from 'lodash.shuffle'
 
 import { stubGame } from '../../../test-utils/stubs/game'
-import { carrot, pumpkin, water } from '../../cards'
+import { carrot, instantiate, pumpkin, water } from '../../cards'
 import { ICard, IGame, IPlayer } from '../../types'
 import { updatePlayer } from '../update-player'
 
@@ -93,9 +93,13 @@ describe('drawCard', () => {
 
       const [player1Id] = Object.keys(game.table.players)
 
-      const deck = [pumpkin.id, water.id, pumpkin.id]
-      const discardPile = [water.id, carrot.id]
-      const hand = [pumpkin.id]
+      const deck = [
+        instantiate(pumpkin),
+        instantiate(water),
+        instantiate(pumpkin),
+      ]
+      const discardPile = [instantiate(water), instantiate(carrot)]
+      const hand = [instantiate(pumpkin)]
       game = updatePlayer(game, player1Id, { deck, discardPile, hand })
 
       const newGame = drawCard(

--- a/src/game/reducers/draw-valid-starting-hand/index.test.ts
+++ b/src/game/reducers/draw-valid-starting-hand/index.test.ts
@@ -1,8 +1,10 @@
 import { randomNumber } from '../../../services/RandomNumber'
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { stubPlayer1 } from '../../../test-utils/stubs/players'
-import { carrot, water } from '../../cards'
+import { instantiate, water } from '../../cards'
 import { DECK_SIZE } from '../../config'
+import { CardInstance, IPlayer } from '../../types'
 import { updatePlayer } from '../update-player'
 
 import { drawValidStartingHand } from '.'
@@ -13,10 +15,13 @@ describe('drawValidStartingHand', () => {
 
     let game = stubGame()
 
-    const hand: string[] = []
+    const hand: IPlayer['hand'] = []
 
     // NOTE: The one crop card is placed at the bottom of the deck here
-    const deck = [...new Array<string>(DECK_SIZE - 1).fill(water.id), carrot.id]
+    const deck = [
+      ...new Array<CardInstance>(DECK_SIZE - 1).fill(instantiate(water)),
+      stubCarrot,
+    ]
 
     game = updatePlayer(game, stubPlayer1.id, {
       hand,
@@ -25,6 +30,6 @@ describe('drawValidStartingHand', () => {
 
     game = drawValidStartingHand(game, stubPlayer1)
 
-    expect(game.table.players[stubPlayer1.id].hand).toContain(carrot.id)
+    expect(game.table.players[stubPlayer1.id].hand).toContain(stubCarrot)
   })
 })

--- a/src/game/reducers/move-crop-from-hand-to-field/index.test.ts
+++ b/src/game/reducers/move-crop-from-hand-to-field/index.test.ts
@@ -1,11 +1,10 @@
+import { stubCarrot, stubWater } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
-import { carrot, water } from '../../cards'
-import { IPlayedCrop } from '../../types'
-
 import {
   InvalidCardError,
   InvalidCardIndexError,
 } from '../../services/Rules/errors'
+import { IPlayedCrop } from '../../types'
 
 import { moveCropFromHandToField } from '.'
 
@@ -15,7 +14,7 @@ describe('moveCropFromHandToField', () => {
     const [player1Id] = Object.keys(game.table.players)
 
     // eslint-disable-next-line functional/immutable-data
-    game.table.players[player1Id].hand[0] = carrot.id
+    game.table.players[player1Id].hand[0] = stubCarrot
     const newGame = moveCropFromHandToField(game, player1Id, 0)
 
     expect(newGame.table.players[player1Id].hand).toEqual(
@@ -23,7 +22,7 @@ describe('moveCropFromHandToField', () => {
     )
 
     expect(newGame.table.players[player1Id].field.crops).toEqual<IPlayedCrop[]>(
-      [{ id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 }]
+      [{ instance: stubCarrot, wasWateredTuringTurn: false, waterCards: 0 }]
     )
   })
 
@@ -45,7 +44,7 @@ describe('moveCropFromHandToField', () => {
     const [player1Id] = Object.keys(game.table.players)
 
     // eslint-disable-next-line functional/immutable-data
-    game.table.players[player1Id].hand[0] = water.id
+    game.table.players[player1Id].hand[0] = stubWater
 
     expect(() => {
       moveCropFromHandToField(game, player1Id, 0)

--- a/src/game/reducers/move-crop-from-hand-to-field/index.ts
+++ b/src/game/reducers/move-crop-from-hand-to-field/index.ts
@@ -18,10 +18,10 @@ export const moveCropFromHandToField = (
   }
 
   const newHand = array.removeAt(hand, cropCardIdx)
-  const cropCard = lookup.getCropFromHand(game, playerId, cropCardIdx)
+  const cropInstance = lookup.getCropFromHand(game, playerId, cropCardIdx)
 
   const playedCropCard: IPlayedCrop = {
-    id: cropCard.id,
+    instance: cropInstance,
     wasWateredTuringTurn: false,
     waterCards: 0,
   }

--- a/src/game/reducers/move-from-hand-to-discard-pile/index.test.ts
+++ b/src/game/reducers/move-from-hand-to-discard-pile/index.test.ts
@@ -1,6 +1,7 @@
 import { stubGame } from '../../../test-utils/stubs/game'
-import { carrot } from '../../cards'
 import { InvalidCardIndexError } from '../../services/Rules/errors'
+
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 
 import { moveFromHandToDiscardPile } from '.'
 
@@ -10,14 +11,14 @@ describe('moveFromHandToDiscardPile', () => {
     const [player1Id] = Object.keys(game.table.players)
 
     // eslint-disable-next-line functional/immutable-data
-    game.table.players[player1Id].hand[0] = carrot.id
+    game.table.players[player1Id].hand[0] = stubCarrot
     const newGame = moveFromHandToDiscardPile(game, player1Id, 0)
 
     expect(newGame.table.players[player1Id].hand).toEqual(
       game.table.players[player1Id].hand.slice(1)
     )
 
-    expect(newGame.table.players[player1Id].discardPile).toEqual([carrot.id])
+    expect(newGame.table.players[player1Id].discardPile).toEqual([stubCarrot])
   })
 
   test('throws an error if an invalid card is specified', () => {

--- a/src/game/reducers/pull-card-from-deck/index.test.ts
+++ b/src/game/reducers/pull-card-from-deck/index.test.ts
@@ -1,11 +1,11 @@
 import shuffle from 'lodash.shuffle'
 import { MockInstance } from 'vitest'
 
+import { stubPumpkin, stubWater } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { stubPlayer1 } from '../../../test-utils/stubs/players'
-import { pumpkin, water } from '../../cards'
 import { InvalidCardIndexError } from '../../services/Rules/errors'
-import { ICard } from '../../types'
+import { ICard, IPlayer } from '../../types'
 import { updatePlayer } from '../update-player'
 
 import { pullCardFromDeck } from '.'
@@ -37,14 +37,14 @@ describe('pullCardFromDeck', () => {
     let game = stubGame()
     const player1Id = stubPlayer1.id
 
-    const deck = [pumpkin.id, water.id]
-    const hand: string[] = []
+    const deck = [stubPumpkin, stubWater]
+    const hand: IPlayer['hand'] = []
 
     game = updatePlayer(game, player1Id, { deck, hand })
     game = pullCardFromDeck(game, player1Id, 1)
 
-    expect(game.table.players[player1Id].hand).toEqual([water.id])
-    expect(game.table.players[player1Id].deck).toEqual([pumpkin.id])
+    expect(game.table.players[player1Id].hand).toEqual([stubWater])
+    expect(game.table.players[player1Id].deck).toEqual([stubPumpkin])
   })
 
   describe('drawing the last card in the deck', () => {
@@ -53,9 +53,9 @@ describe('pullCardFromDeck', () => {
 
       const [player1Id] = Object.keys(game.table.players)
 
-      const deck = [pumpkin.id]
-      const discardPile = [water.id]
-      const hand: string[] = []
+      const deck = [stubPumpkin]
+      const discardPile = [stubWater]
+      const hand: IPlayer['hand'] = []
       game = updatePlayer(game, player1Id, { deck, discardPile, hand })
 
       const newGame = pullCardFromDeck(game, player1Id, 0)
@@ -73,8 +73,8 @@ describe('pullCardFromDeck', () => {
     let game = stubGame()
     const player1Id = stubPlayer1.id
 
-    const deck = [pumpkin.id, water.id]
-    const hand: string[] = []
+    const deck = [stubPumpkin, stubWater]
+    const hand: IPlayer['hand'] = []
 
     game = updatePlayer(game, player1Id, { deck, hand })
 

--- a/src/game/reducers/start-turn/index.test.ts
+++ b/src/game/reducers/start-turn/index.test.ts
@@ -1,8 +1,9 @@
 import shuffle from 'lodash.shuffle'
 import { MockInstance } from 'vitest'
 
+import { stubPumpkin } from '../../../test-utils/stubs/cards'
 import { stubPlayer } from '../../../test-utils/stubs/players'
-import { carrot, pumpkin } from '../../cards'
+import { carrot, instantiate } from '../../cards'
 import { DECK_SIZE, STANDARD_TAX_AMOUNT } from '../../config'
 import { updatePlayer } from '../../reducers/update-player'
 import { factory } from '../../services/Factory'
@@ -30,7 +31,7 @@ beforeEach(() => {
 // Make player2's deck slightly different from player1's to prevent false
 // positives.
 // eslint-disable-next-line functional/immutable-data
-player2.deck[DECK_SIZE - 1] = pumpkin.id
+player2.deck[DECK_SIZE - 1] = stubPumpkin
 
 describe('startTurn', () => {
   let game: IGame
@@ -77,12 +78,16 @@ describe('startTurn', () => {
   })
 
   test('resets wasWateredTuringTurn for each crop in the field', () => {
+    const carrot1 = instantiate(carrot)
+    const carrot2 = instantiate(carrot)
+    const carrot3 = instantiate(carrot)
+
     let newGame = updatePlayer(game, player1Id, {
       field: {
         crops: [
-          { id: carrot.id, wasWateredTuringTurn: true, waterCards: 1 },
-          { id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 },
-          { id: carrot.id, wasWateredTuringTurn: true, waterCards: 1 },
+          { instance: carrot1, wasWateredTuringTurn: true, waterCards: 1 },
+          { instance: carrot2, wasWateredTuringTurn: false, waterCards: 0 },
+          { instance: carrot3, wasWateredTuringTurn: true, waterCards: 1 },
         ],
       },
     })
@@ -91,9 +96,9 @@ describe('startTurn', () => {
 
     expect(newGame.table.players[player1Id].field.crops).toEqual<IPlayedCrop[]>(
       [
-        { id: carrot.id, wasWateredTuringTurn: false, waterCards: 1 },
-        { id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 },
-        { id: carrot.id, wasWateredTuringTurn: false, waterCards: 1 },
+        { instance: carrot1, wasWateredTuringTurn: false, waterCards: 1 },
+        { instance: carrot2, wasWateredTuringTurn: false, waterCards: 0 },
+        { instance: carrot3, wasWateredTuringTurn: false, waterCards: 1 },
       ]
     )
   })

--- a/src/game/reducers/update-field/index.test.ts
+++ b/src/game/reducers/update-field/index.test.ts
@@ -1,6 +1,8 @@
 import { stubGame } from '../../../test-utils/stubs/game'
-import { carrot } from '../../cards'
 import { IField } from '../../types'
+
+import { factory } from '../../services/Factory'
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 
 import { updateField } from '.'
 
@@ -9,7 +11,7 @@ describe('updateField', () => {
     const game = stubGame()
     const [player1Id] = Object.keys(game.table.players)
     const field: IField = {
-      crops: [{ ...carrot, wasWateredTuringTurn: false, waterCards: 0 }],
+      crops: [factory.buildPlayedCrop(stubCarrot)],
     }
 
     const newGame = updateField(game, player1Id, field)

--- a/src/game/reducers/update-played-crop/index.test.ts
+++ b/src/game/reducers/update-played-crop/index.test.ts
@@ -1,5 +1,5 @@
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
-import { carrot } from '../../cards'
 import { factory } from '../../services/Factory'
 import { updateField } from '../update-field'
 
@@ -10,7 +10,7 @@ const [player1Id] = Object.keys(game.table.players)
 
 describe('updatePlayedCrop', () => {
   test('updates crop in field', () => {
-    const playedCrop = factory.buildPlayedCrop(carrot)
+    const playedCrop = factory.buildPlayedCrop(stubCarrot)
     const field = {
       crops: [playedCrop],
     }
@@ -24,7 +24,7 @@ describe('updatePlayedCrop', () => {
   })
 
   test('throws an error if invalid cropIdx is provided', () => {
-    const playedCrop = factory.buildPlayedCrop(carrot)
+    const playedCrop = factory.buildPlayedCrop(stubCarrot)
     const field = {
       crops: [playedCrop],
     }

--- a/src/game/services/BotLogic/index.test.ts
+++ b/src/game/services/BotLogic/index.test.ts
@@ -1,10 +1,10 @@
 import { randomNumber } from '../../../services/RandomNumber'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { stubPlayer1 } from '../../../test-utils/stubs/players'
-import { carrot, water } from '../../cards'
+import { carrot, instantiate, water } from '../../cards'
 import { STANDARD_FIELD_SIZE } from '../../config'
 import { updatePlayer } from '../../reducers/update-player'
-import { IPlayedCrop } from '../../types'
+import { IField, IPlayedCrop, IPlayer } from '../../types'
 
 import { botLogic } from '.'
 
@@ -21,7 +21,7 @@ describe('BotLogicService', () => {
 
       {
         rngStub: 0,
-        hand: [carrot.id],
+        hand: [instantiate(carrot)],
         fieldCrops: [],
         minimumCropsToPlay: 1,
         expectedResult: 1,
@@ -29,7 +29,7 @@ describe('BotLogicService', () => {
 
       {
         rngStub: 1,
-        hand: [carrot.id],
+        hand: [instantiate(carrot)],
         fieldCrops: [],
         minimumCropsToPlay: 1,
         expectedResult: 1,
@@ -37,7 +37,7 @@ describe('BotLogicService', () => {
 
       {
         rngStub: 1,
-        hand: [carrot.id],
+        hand: [instantiate(carrot)],
         fieldCrops: [],
         minimumCropsToPlay: 1,
         expectedResult: 1,
@@ -45,7 +45,7 @@ describe('BotLogicService', () => {
 
       {
         rngStub: 0,
-        hand: [carrot.id, carrot.id],
+        hand: [instantiate(carrot), instantiate(carrot)],
         fieldCrops: [],
         minimumCropsToPlay: 1,
         expectedResult: 1,
@@ -53,7 +53,7 @@ describe('BotLogicService', () => {
 
       {
         rngStub: 1,
-        hand: [carrot.id, carrot.id],
+        hand: [instantiate(carrot), instantiate(carrot)],
         fieldCrops: [],
         minimumCropsToPlay: 1,
         expectedResult: 2,
@@ -61,9 +61,9 @@ describe('BotLogicService', () => {
 
       {
         rngStub: 1,
-        hand: [carrot.id, carrot.id],
+        hand: [instantiate(carrot), instantiate(carrot)],
         fieldCrops: new Array<IPlayedCrop>(STANDARD_FIELD_SIZE - 1).fill({
-          id: carrot.id,
+          instance: instantiate(carrot),
           wasWateredTuringTurn: false,
           waterCards: 0,
         }),
@@ -73,9 +73,9 @@ describe('BotLogicService', () => {
 
       {
         rngStub: 1,
-        hand: [carrot.id],
+        hand: [instantiate(carrot)],
         fieldCrops: new Array<IPlayedCrop>(STANDARD_FIELD_SIZE).fill({
-          id: carrot.id,
+          instance: instantiate(carrot),
           wasWateredTuringTurn: false,
           waterCards: 0,
         }),
@@ -109,13 +109,21 @@ describe('BotLogicService', () => {
   })
 
   describe('getCropCardIndicesToWater', () => {
-    it.each([
+    it.each<{
+      hand: IPlayer['hand']
+      fieldCrops: IField['crops']
+      expectedResult: number[]
+    }>([
       { hand: [], fieldCrops: [], expectedResult: [] },
 
       {
-        hand: [water.id],
+        hand: [instantiate(water)],
         fieldCrops: [
-          { id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 },
+          {
+            instance: instantiate(carrot),
+            wasWateredTuringTurn: false,
+            waterCards: 0,
+          },
         ],
         expectedResult: [0],
       },
@@ -123,32 +131,36 @@ describe('BotLogicService', () => {
       {
         hand: [],
         fieldCrops: [
-          { id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 },
+          {
+            instance: instantiate(carrot),
+            wasWateredTuringTurn: false,
+            waterCards: 0,
+          },
         ],
         expectedResult: [],
       },
 
       {
-        hand: [water.id],
+        hand: [instantiate(water)],
         fieldCrops: [],
         expectedResult: [],
       },
 
       {
-        hand: [water.id, water.id],
+        hand: [instantiate(water), instantiate(water)],
         fieldCrops: [
           {
-            id: carrot.id,
+            instance: instantiate(carrot),
             wasWateredTuringTurn: false,
             waterCards: carrot.waterToMature,
           },
           {
-            id: carrot.id,
+            instance: instantiate(carrot),
             wasWateredTuringTurn: false,
             waterCards: carrot.waterToMature - 1,
           },
           {
-            id: carrot.id,
+            instance: instantiate(carrot),
             wasWateredTuringTurn: false,
             waterCards: carrot.waterToMature,
           },
@@ -157,20 +169,20 @@ describe('BotLogicService', () => {
       },
 
       {
-        hand: [water.id, water.id],
+        hand: [instantiate(water), instantiate(water)],
         fieldCrops: [
           {
-            id: carrot.id,
+            instance: instantiate(carrot),
             wasWateredTuringTurn: false,
             waterCards: carrot.waterToMature - 1,
           },
           {
-            id: carrot.id,
+            instance: instantiate(carrot),
             wasWateredTuringTurn: false,
             waterCards: carrot.waterToMature,
           },
           {
-            id: carrot.id,
+            instance: instantiate(carrot),
             wasWateredTuringTurn: false,
             waterCards: carrot.waterToMature - 1,
           },
@@ -179,15 +191,15 @@ describe('BotLogicService', () => {
       },
 
       {
-        hand: [water.id, water.id],
+        hand: [instantiate(water), instantiate(water)],
         fieldCrops: [
           {
-            id: carrot.id,
+            instance: instantiate(carrot),
             wasWateredTuringTurn: true,
             waterCards: carrot.waterToMature - 1,
           },
           {
-            id: carrot.id,
+            instance: instantiate(carrot),
             wasWateredTuringTurn: false,
             waterCards: carrot.waterToMature - 1,
           },

--- a/src/game/services/BotLogic/index.ts
+++ b/src/game/services/BotLogic/index.ts
@@ -1,7 +1,6 @@
-import * as cards from '../../../game/cards'
 import { randomNumber } from '../../../services/RandomNumber'
 import { STANDARD_FIELD_SIZE } from '../../config'
-import { IGame, isCropCard, isWaterCard } from '../../types'
+import { IGame, isCropCardInstance, isWaterCardInstance } from '../../types'
 import { assertIsCardId } from '../../types/guards'
 import { lookup } from '../Lookup'
 
@@ -40,10 +39,8 @@ export class BotLogicService {
     } = game.table.players[playerId]
 
     let fieldCropIdxsThatNeedWater: number[] = []
-    const { length: numberOfWaterCardsInHand } = hand.filter(cardId => {
-      assertIsCardId(cardId)
-
-      return isWaterCard(cards[cardId])
+    const { length: numberOfWaterCardsInHand } = hand.filter(cardInstance => {
+      return isWaterCardInstance(cardInstance)
     })
 
     for (let i = 0; i < crops.length; i++) {
@@ -53,12 +50,11 @@ export class BotLogicService {
       }
 
       const plantedCrop = crops[i]
-      assertIsCardId(plantedCrop.id)
-      const card = cards[plantedCrop.id]
+      assertIsCardId(plantedCrop.instance.id)
 
-      if (isCropCard(card)) {
+      if (isCropCardInstance(plantedCrop.instance)) {
         if (
-          plantedCrop.waterCards < card.waterToMature &&
+          plantedCrop.waterCards < plantedCrop.instance.waterToMature &&
           plantedCrop.wasWateredTuringTurn === false
         ) {
           fieldCropIdxsThatNeedWater = [...fieldCropIdxsThatNeedWater, i]

--- a/src/game/services/Factory/index.test.ts
+++ b/src/game/services/Factory/index.test.ts
@@ -1,11 +1,11 @@
 import shuffle from 'lodash.shuffle'
 import { MockInstance } from 'vitest'
 
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 import { stubPlayer } from '../../../test-utils/stubs/players'
-import { isField, isGame, isPlayer, isTable } from '../../types/guards'
-import { carrot } from '../../cards'
 import { INITIAL_HAND_SIZE, INITIAL_PLAYER_FUNDS } from '../../config'
 import { ICard, IPlayedCrop } from '../../types'
+import { isField, isGame, isPlayer, isTable } from '../../types/guards'
 
 import { factory } from '.'
 
@@ -99,10 +99,10 @@ describe('Factory', () => {
 
   describe('buildPlayedCrop', () => {
     test('builds a played crop', () => {
-      const playedCard = factory.buildPlayedCrop(carrot)
+      const playedCard = factory.buildPlayedCrop(stubCarrot)
 
       expect(playedCard).toEqual<IPlayedCrop>({
-        id: carrot.id,
+        instance: stubCarrot,
         wasWateredTuringTurn: false,
         waterCards: 0,
       })

--- a/src/game/services/Factory/index.ts
+++ b/src/game/services/Factory/index.ts
@@ -2,10 +2,11 @@ import { v4 as uuid } from 'uuid'
 
 import { INITIAL_PLAYER_FUNDS } from '../../config'
 import { drawValidStartingHand } from '../../reducers/draw-valid-starting-hand'
+import { shuffleDeck } from '../../reducers/shuffle-deck'
 import { updateGame } from '../../reducers/update-game'
 import { updateTable } from '../../reducers/update-table'
 import {
-  ICrop,
+  CropInstance,
   IField,
   IGame,
   IPlayedCrop,
@@ -14,7 +15,6 @@ import {
   ITable,
 } from '../../types'
 import { validate } from '../Validation'
-import { shuffleDeck } from '../../reducers/shuffle-deck'
 
 export class FactoryService {
   buildField(overrides: Partial<IField> = {}): IField {
@@ -109,9 +109,9 @@ export class FactoryService {
     return game
   }
 
-  buildPlayedCrop({ id }: ICrop): IPlayedCrop {
+  buildPlayedCrop(cropInstance: CropInstance): IPlayedCrop {
     return {
-      id,
+      instance: cropInstance,
       wasWateredTuringTurn: false,
       waterCards: 0,
     }

--- a/src/game/services/Lookup/index.test.ts
+++ b/src/game/services/Lookup/index.test.ts
@@ -1,12 +1,13 @@
 import { test } from 'vitest'
 
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { stubPlayer1 } from '../../../test-utils/stubs/players'
-import { carrot, pumpkin, water } from '../../cards'
+import { carrot, instantiate, pumpkin, water } from '../../cards'
 import { updatePlayer } from '../../reducers/update-player'
 import { IGame, IPlayer } from '../../types'
 import { isPlayer } from '../../types/guards'
-import { GameStateCorruptError, InvalidIdError } from '../Rules/errors'
+import { InvalidIdError } from '../Rules/errors'
 
 import { lookup } from '.'
 
@@ -22,13 +23,13 @@ describe('Lookup', () => {
       player1Id = Object.keys(mutatedGame.table.players)[0]
 
       // eslint-disable-next-line functional/immutable-data
-      mutatedGame.table.players[player1Id].hand[0] = carrot.id
+      mutatedGame.table.players[player1Id].hand[0] = stubCarrot
     })
 
     test('returns card from hand', () => {
-      const card = lookup.getCardFromHand(mutatedGame, player1Id, 0)
+      const cardInstance = lookup.getCardFromHand(mutatedGame, player1Id, 0)
 
-      expect(card).toBe(carrot)
+      expect(cardInstance).toBe(stubCarrot)
     })
 
     test('throws an error when specified card is not in hand', () => {
@@ -39,16 +40,6 @@ describe('Lookup', () => {
           mutatedGame.table.players[player1Id].hand.length
         )
       }).toThrow()
-    })
-
-    test('throws an error when specified card is not valid', () => {
-      mutatedGame = updatePlayer(mutatedGame, player1Id, {
-        hand: ['some-card-that-does-not-exist'],
-      })
-
-      expect(() => {
-        lookup.getCardFromHand(mutatedGame, player1Id, 0)
-      }).toThrow(GameStateCorruptError)
     })
   })
 
@@ -80,9 +71,13 @@ describe('Lookup', () => {
     test.each([
       { deck: [], howMany: undefined, expected: [] },
       { deck: [], howMany: 1, expected: [] },
-      { deck: [carrot.id], howMany: 1, expected: [0] },
-      { deck: [water.id], howMany: 1, expected: [] },
-      { deck: [carrot.id, water.id, carrot.id], howMany: 3, expected: [0, 2] },
+      { deck: [instantiate(carrot)], howMany: 1, expected: [0] },
+      { deck: [instantiate(water)], howMany: 1, expected: [] },
+      {
+        deck: [instantiate(carrot), instantiate(water), instantiate(carrot)],
+        howMany: 3,
+        expected: [0, 2],
+      },
     ])(
       'retrieves $howMany crop indices in deck ($deck)',
       ({ deck, howMany, expected }) => {
@@ -106,9 +101,14 @@ describe('Lookup', () => {
   describe('findCropIndexesInPlayerHand', () => {
     test.each([
       { hand: [], expected: [] },
-      { hand: [carrot.id], expected: [0] },
+      { hand: [instantiate(carrot)], expected: [0] },
       {
-        hand: [carrot.id, water.id, water.id, pumpkin.id],
+        hand: [
+          instantiate(carrot),
+          instantiate(water),
+          instantiate(water),
+          instantiate(pumpkin),
+        ],
         expected: [0, 3],
       },
     ])('retrieves crop indices in hand ($hand)', ({ hand, expected }) => {

--- a/src/game/services/Lookup/index.ts
+++ b/src/game/services/Lookup/index.ts
@@ -1,41 +1,32 @@
-import * as cards from '../../cards'
-import { ICard, IGame, IPlayer, isCropCard } from '../../types'
-import { assertIsCardId, isCrop } from '../../types/guards'
+import { IGame, IPlayer, isCropCardInstance } from '../../types'
+import { isCrop } from '../../types/guards'
 import { InvalidCardError, InvalidIdError } from '../Rules/errors'
 
 export class LookupService {
-  getCardFromHand = (
-    game: IGame,
-    playerId: IPlayer['id'],
-    cardIdx: number
-  ): ICard => {
+  getCardFromHand = (game: IGame, playerId: IPlayer['id'], cardIdx: number) => {
     const { hand } = game.table.players[playerId]
-    const cardId = hand[cardIdx]
+    const cardInstance = hand[cardIdx]
 
-    if (!cardId) {
+    if (!cardInstance) {
       throw new Error(
         `Card index ${cardIdx} is not in player ${playerId}'s hand`
       )
     }
 
-    assertIsCardId(cardId)
-
-    const card = cards[cardId]
-
-    return card
+    return cardInstance
   }
 
   /**
-   * @throws InvalidCardError if card is not an ICrop.
+   * @throws InvalidCardError if card is not a CropInstance.
    */
   getCropFromHand(game: IGame, playerId: IPlayer['id'], cardIdx: number) {
-    const card = this.getCardFromHand(game, playerId, cardIdx)
+    const cropInstance = this.getCardFromHand(game, playerId, cardIdx)
 
-    if (!isCrop(card)) {
-      throw new InvalidCardError(`${card.id} is not a crop card.`)
+    if (!isCrop(cropInstance)) {
+      throw new InvalidCardError(`${cropInstance.id} is not a crop card.`)
     }
 
-    return card
+    return cropInstance
   }
 
   /**
@@ -78,13 +69,9 @@ export class LookupService {
       i < howMany && i <= deck.length - 1 && cropCardIdxs.length < howMany;
       i++
     ) {
-      const cardId = deck[i]
+      const cardInstance = deck[i]
 
-      assertIsCardId(cardId)
-
-      const card = cards[cardId]
-
-      if (isCropCard(card)) {
+      if (isCropCardInstance(cardInstance)) {
         cropCardIdxs = [...cropCardIdxs, i]
       }
     }
@@ -94,12 +81,8 @@ export class LookupService {
 
   findCropIndexesInPlayerHand = (game: IGame, playerId: IPlayer['id']) => {
     const cropCardIdxsInPlayerHand = game.table.players[playerId].hand.reduce(
-      (acc: number[], cardId, idx) => {
-        assertIsCardId(cardId)
-
-        const card = cards[cardId]
-
-        if (isCropCard(card)) {
+      (acc: number[], cardInstance, idx) => {
+        if (isCropCardInstance(cardInstance)) {
           acc = [...acc, idx]
         }
 

--- a/src/game/services/Rules/state-machine/performingBotCropWateringState.ts
+++ b/src/game/services/Rules/state-machine/performingBotCropWateringState.ts
@@ -1,10 +1,14 @@
 import { enqueueActions } from 'xstate'
 
-import * as cards from '../../../cards'
 import { moveFromHandToDiscardPile } from '../../../reducers/move-from-hand-to-discard-pile'
 import { updatePlayedCrop } from '../../../reducers/update-played-crop'
-import { GameEvent, GameState, IPlayedCrop, isWaterCard } from '../../../types'
-import { assertCurrentPlayer, assertIsCardId } from '../../../types/guards'
+import {
+  GameEvent,
+  GameState,
+  IPlayedCrop,
+  isWaterCardInstance,
+} from '../../../types'
+import { assertCurrentPlayer } from '../../../types/guards'
 import { GameStateCorruptError } from '../errors'
 
 import { RulesMachineConfig } from './types'
@@ -26,11 +30,8 @@ export const performingBotCropWateringState: RulesMachineConfig['states'] = {
 
         const waterCardInHandIdx = game.table.players[
           currentPlayerId
-        ].hand.findIndex(cardId => {
-          assertIsCardId(cardId)
-          const card = cards[cardId]
-
-          return isWaterCard(card)
+        ].hand.findIndex(cardInstance => {
+          return isWaterCardInstance(cardInstance)
         })
 
         const [cropIdxInFieldToWater] = fieldCropIndicesToWaterDuringBotTurn

--- a/src/game/services/Validation/index.test.ts
+++ b/src/game/services/Validation/index.test.ts
@@ -1,5 +1,5 @@
+import { stubCarrot, stubWater } from '../../../test-utils/stubs/cards'
 import { stubPlayer } from '../../../test-utils/stubs/players'
-import { carrot, water } from '../../cards'
 import { GameStateCorruptError } from '../Rules/errors'
 
 import { validate } from './' // Update path accordingly
@@ -7,7 +7,7 @@ import { validate } from './' // Update path accordingly
 describe('ValidationService', () => {
   it('should return true when player deck contains at least one crop', () => {
     const player = stubPlayer({
-      deck: [carrot.id],
+      deck: [stubCarrot],
     })
 
     expect(validate.player(player)).toBe(true)
@@ -15,7 +15,8 @@ describe('ValidationService', () => {
 
   it('should throw GameStateCorruptError if a card ID is invalid', () => {
     const player = stubPlayer({
-      deck: ['some-nonexistent-card'],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      deck: [{ id: 'some-nonexistent-card' } as any],
     })
 
     expect(() => validate.player(player)).toThrow(GameStateCorruptError)
@@ -23,12 +24,14 @@ describe('ValidationService', () => {
 
   it("should throw GameStateCorruptError if no crops are found in the player's deck", () => {
     const player = stubPlayer({
-      deck: [water.id],
+      deck: [stubWater],
     })
 
     expect(() => validate.player(player)).toThrow(GameStateCorruptError)
   })
 
+  // TODO: Revisit this. It should be valid for the player to have an empty
+  // deck.
   it('should throw GameStateCorruptError if deck is empty', () => {
     const player = stubPlayer({
       deck: [],

--- a/src/game/services/Validation/index.ts
+++ b/src/game/services/Validation/index.ts
@@ -1,6 +1,4 @@
-import * as cards from '../../cards'
-import { IPlayer, isCropCard } from '../../types'
-import { assertIsCardId } from '../../types/guards'
+import { IPlayer, isCropCardInstance } from '../../types'
 import { GameStateCorruptError } from '../Rules/errors'
 
 export class ValidationService {
@@ -9,12 +7,8 @@ export class ValidationService {
    *   - That player deck contains at least one crop
    */
   player = (player: IPlayer) => {
-    const deckContainsCrop = player.deck.some(cardId => {
-      assertIsCardId(cardId)
-
-      const card = cards[cardId]
-
-      return isCropCard(card)
+    const deckContainsCrop = player.deck.some(cardInstance => {
+      return isCropCardInstance(cardInstance)
     })
 
     if (!deckContainsCrop) {

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -1,6 +1,29 @@
+import {
+  CardInstance,
+  CardType,
+  GameState,
+  ICrop,
+  IField,
+  IGame,
+  IPlayer,
+  ITable,
+} from '../'
 import * as cards from '../../cards'
-import { CardType, GameState, ICrop, IField, IGame, IPlayer, ITable } from '../'
 import { GameStateCorruptError } from '../../services/Rules/errors'
+
+export const isCardInstance = (obj: unknown): obj is CardInstance => {
+  if (typeof obj !== 'object' || obj === null) return false
+
+  return (
+    'id' in obj &&
+    typeof obj.id === 'string' &&
+    'type' in obj &&
+    typeof obj.type === 'string' &&
+    obj.type in CardType &&
+    'instanceId' in obj &&
+    typeof obj.instanceId === 'string'
+  )
+}
 
 export const isCrop = (obj: unknown): obj is ICrop => {
   if (typeof obj !== 'object' || obj === null) return false
@@ -19,6 +42,7 @@ export const isField = (obj: unknown): obj is IField => {
   return (
     'crops' in obj &&
     Array.isArray(obj.crops) &&
+    // TODO: This should be verifying that the contents are IPlayedCrops
     obj.crops.every(crop => isCrop(crop) || crop === undefined)
   )
 }
@@ -33,13 +57,13 @@ export const isPlayer = (obj: unknown): obj is IPlayer => {
     typeof obj.funds === 'number' &&
     'deck' in obj &&
     Array.isArray(obj.deck) &&
-    obj.deck.every(card => typeof card === 'string') &&
+    obj.deck.every(isCardInstance) &&
     'hand' in obj &&
     Array.isArray(obj.hand) &&
-    obj.hand.every(card => typeof card === 'string') &&
+    obj.hand.every(isCardInstance) &&
     'discardPile' in obj &&
     Array.isArray(obj.discardPile) &&
-    obj.discardPile.every(card => typeof card === 'string') &&
+    obj.discardPile.every(isCardInstance) &&
     'field' in obj &&
     isField(obj.field)
   )

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -38,6 +38,10 @@ export interface ICard {
   ) => GameEventPayload[GameEventPayloadKey]
 }
 
+export interface Instance {
+  instanceId: uuidString
+}
+
 export interface ICrop extends ICard {
   readonly type: CardType.CROP
 
@@ -48,8 +52,12 @@ export interface ICrop extends ICard {
   readonly waterToMature: number
 }
 
-export const isCropCard = (card: ICard): card is ICrop => {
-  return card.type === CardType.CROP
+export interface CropInstance extends ICrop, Instance {}
+
+export const isCropCardInstance = (
+  cardInstance: CardInstance
+): cardInstance is CropInstance => {
+  return cardInstance.type === CardType.CROP
 }
 
 /**
@@ -57,9 +65,9 @@ export const isCropCard = (card: ICard): card is ICrop => {
  */
 export interface IPlayedCrop {
   /**
-   * The card ID of this crop.
+   * The card instance of this crop.
    */
-  readonly id: ICard['id']
+  instance: CropInstance
 
   /**
    * How many water cards are attached to this crop.
@@ -96,8 +104,14 @@ export interface IWater extends ICard {
   readonly type: CardType.WATER
 }
 
-export const isWaterCard = (card: ICard): card is IWater => {
-  return card.type === CardType.WATER
+export interface WaterInstance extends IWater, Instance {}
+
+export type CardInstance = CropInstance | WaterInstance
+
+export const isWaterCardInstance = (
+  cardInstance: CardInstance
+): cardInstance is WaterInstance => {
+  return cardInstance.type === CardType.WATER
 }
 
 export interface IField {
@@ -115,17 +129,17 @@ export interface IPlayer {
   /**
    * Cards that the player can draw from.
    */
-  readonly deck: ICard['id'][]
+  readonly deck: CardInstance[]
 
   /**
    * Cards in the player's hand.
    */
-  readonly hand: ICard['id'][]
+  readonly hand: CardInstance[]
 
   /**
    * Cards that have been used.
    */
-  readonly discardPile: ICard['id'][]
+  readonly discardPile: CardInstance[]
 
   /**
    * Cards in the player's Field.

--- a/src/test-utils/stubs/cards.ts
+++ b/src/test-utils/stubs/cards.ts
@@ -1,0 +1,6 @@
+import { carrot, instantiate, pumpkin, water } from '../../game/cards'
+import { CropInstance, WaterInstance } from '../../game/types'
+
+export const stubCarrot: CropInstance = instantiate(carrot)
+export const stubPumpkin: CropInstance = instantiate(pumpkin)
+export const stubWater: WaterInstance = instantiate(water)

--- a/src/test-utils/stubs/deck.ts
+++ b/src/test-utils/stubs/deck.ts
@@ -1,18 +1,20 @@
 /* eslint-disable functional/immutable-data */
-import { carrot, pumpkin } from '../../game/cards'
+import { carrot, instantiate, pumpkin } from '../../game/cards'
 import { water } from '../../game/cards/water'
 import { DECK_SIZE } from '../../game/config'
-import { ICard, ICrop } from '../../game/types'
+import { CardInstance } from '../../game/types'
 
-export const stubDeck = (): ICrop['id'][] => {
-  const deck = new Array<ICard>(DECK_SIZE)
+export const stubDeck = () => {
+  const deck = new Array<CardInstance>(DECK_SIZE)
 
-  deck.fill(water)
+  for (let i = 0; i < deck.length; i++) {
+    deck[i] = instantiate(water)
+  }
 
-  deck[0] = carrot
-  deck[1] = carrot
-  deck[2] = pumpkin
-  deck[3] = pumpkin
+  deck[0] = instantiate(carrot)
+  deck[1] = instantiate(carrot)
+  deck[2] = instantiate(pumpkin)
+  deck[3] = instantiate(pumpkin)
 
-  return deck.map(({ id }) => id)
+  return deck
 }

--- a/src/ui/components/Card/Card.stories.tsx
+++ b/src/ui/components/Card/Card.stories.tsx
@@ -1,12 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { spyOn } from '@storybook/test'
 
-import { carrot, pumpkin, water } from '../../../game/cards'
 import { GameState } from '../../../game/types'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { stubPlayer1 } from '../../../test-utils/stubs/players'
 import { CardSize } from '../../types'
 import { ActorContext } from '../Game/ActorContext'
+
+import {
+  stubCarrot,
+  stubPumpkin,
+  stubWater,
+} from '../../../test-utils/stubs/cards'
 
 import { Card } from './Card'
 
@@ -25,7 +30,7 @@ type Story = StoryObj<typeof meta>
 
 export const CropCard: Story = {
   args: {
-    card: carrot,
+    cardInstance: stubCarrot,
     cardIdx: 0,
     playerId: '',
     isFlipped: false,
@@ -34,7 +39,7 @@ export const CropCard: Story = {
 
 export const PlayableCropCard: Story = {
   args: {
-    card: pumpkin,
+    cardInstance: stubPumpkin,
     cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
@@ -55,7 +60,7 @@ export const PlayableCropCard: Story = {
 
 export const PlayableWaterCard: Story = {
   args: {
-    card: water,
+    cardInstance: stubWater,
     cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
@@ -76,7 +81,7 @@ export const PlayableWaterCard: Story = {
 
 export const WaterableCropCard: Story = {
   args: {
-    card: pumpkin,
+    cardInstance: stubPumpkin,
     cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
@@ -99,7 +104,7 @@ export const WaterableCropCard: Story = {
 
 export const WaterCard: Story = {
   args: {
-    card: water,
+    cardInstance: stubWater,
     cardIdx: 0,
     playerId: '',
     isFlipped: false,
@@ -108,7 +113,7 @@ export const WaterCard: Story = {
 
 export const SmallCard: Story = {
   args: {
-    card: pumpkin,
+    cardInstance: stubPumpkin,
     cardIdx: 0,
     playerId: '',
     size: CardSize.SMALL,
@@ -118,7 +123,7 @@ export const SmallCard: Story = {
 
 export const MediumCard: Story = {
   args: {
-    card: pumpkin,
+    cardInstance: stubPumpkin,
     cardIdx: 0,
     playerId: '',
     isFlipped: false,
@@ -128,7 +133,7 @@ export const MediumCard: Story = {
 
 export const LargeCard: Story = {
   args: {
-    card: pumpkin,
+    cardInstance: stubPumpkin,
     cardIdx: 0,
     playerId: '',
     isFlipped: false,

--- a/src/ui/components/Card/Card.test.tsx
+++ b/src/ui/components/Card/Card.test.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 
-import { carrot, water } from '../../../game/cards'
 import { RulesService } from '../../../game/services/Rules'
 import { GameEvent, GameEventPayload, GameState } from '../../../game/types'
 import { mockSend } from '../../../test-utils/mocks/send'
+import { stubCarrot, stubWater } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { stubPlayer1 } from '../../../test-utils/stubs/players'
 import * as useGameStateModule from '../../hooks/useGameRules'
@@ -14,12 +14,17 @@ import { ActorContext } from '../Game/ActorContext'
 import { Card, CardProps } from './Card'
 import { cardFlipWrapperClassName } from './CardTemplate'
 
-const stubCard = carrot
+const stubCardInstance = stubCarrot
 
 const StubCard = ({ ref, ...overrides }: Partial<CardProps> = {}) => (
   <StubShellContext>
     <ActorContext.Provider>
-      <Card card={stubCard} cardIdx={0} playerId="" {...overrides} />
+      <Card
+        cardInstance={stubCardInstance}
+        cardIdx={0}
+        playerId=""
+        {...overrides}
+      />
     </ActorContext.Provider>
   </StubShellContext>
 )
@@ -28,15 +33,17 @@ describe('Card', () => {
   test('renders card', () => {
     render(<StubCard />)
 
-    expect(screen.getByText(stubCard.name)).toBeInTheDocument()
-    expect(screen.getByAltText(stubCard.name)).toBeInTheDocument()
+    expect(screen.getByText(stubCardInstance.name)).toBeInTheDocument()
+    expect(screen.getByAltText(stubCardInstance.name)).toBeInTheDocument()
   })
 
   test('renders crop water requirements', () => {
     render(<StubCard />)
 
     expect(
-      screen.getByText(`Water needed to mature: ${stubCard.waterToMature}`)
+      screen.getByText(
+        `Water needed to mature: ${stubCardInstance.waterToMature}`
+      )
     ).toBeInTheDocument()
   })
 
@@ -46,7 +53,7 @@ describe('Card', () => {
     render(
       <StubCard
         playedCrop={{
-          id: stubCard.id,
+          instance: stubCardInstance,
           wasWateredTuringTurn: false,
           waterCards,
         }}
@@ -55,7 +62,7 @@ describe('Card', () => {
 
     expect(
       screen.getByText(
-        `Water cards attached: ${waterCards}/${stubCard.waterToMature}`
+        `Water cards attached: ${waterCards}/${stubCardInstance.waterToMature}`
       )
     ).toBeInTheDocument()
   })
@@ -64,7 +71,7 @@ describe('Card', () => {
     render(<StubCard />)
 
     const card = screen
-      .getByText(stubCard.name)
+      .getByText(stubCardInstance.name)
       .closest(`.${cardFlipWrapperClassName}`)
 
     const { transform } = getComputedStyle(card!)
@@ -75,7 +82,7 @@ describe('Card', () => {
     render(<StubCard isFlipped={true} />)
 
     const card = screen
-      .getByText(stubCard.name)
+      .getByText(stubCardInstance.name)
       .closest(`.${cardFlipWrapperClassName}`)
 
     const { transform } = getComputedStyle(card!)
@@ -97,7 +104,13 @@ describe('Card', () => {
           RulesService.defaultSelectedWaterCardInHandIdx,
       })
 
-      render(<StubCard card={carrot} playerId={stubPlayer1.id} isFocused />)
+      render(
+        <StubCard
+          cardInstance={stubCarrot}
+          playerId={stubPlayer1.id}
+          isFocused
+        />
+      )
 
       const playCardButton = screen.getByText('Play crop')
 
@@ -124,7 +137,13 @@ describe('Card', () => {
           RulesService.defaultSelectedWaterCardInHandIdx,
       })
 
-      render(<StubCard card={water} playerId={stubPlayer1.id} isFocused />)
+      render(
+        <StubCard
+          cardInstance={stubWater}
+          playerId={stubPlayer1.id}
+          isFocused
+        />
+      )
 
       const playCardButton = screen.getByText('Water a crop')
 
@@ -152,7 +171,7 @@ describe('Card', () => {
 
     render(
       <StubCard
-        card={carrot}
+        cardInstance={stubCarrot}
         playerId={stubPlayer1.id}
         isFocused
         isInField

--- a/src/ui/components/Card/Card.tsx
+++ b/src/ui/components/Card/Card.tsx
@@ -4,10 +4,10 @@ import { forwardRef } from 'react'
 
 import { UnimplementedError } from '../../../game/services/Rules/errors'
 import {
-  ICard,
+  CardInstance,
   IPlayedCrop,
-  isCropCard,
-  isWaterCard,
+  isCropCardInstance,
+  isWaterCardInstance,
 } from '../../../game/types'
 import { isCrop } from '../../../game/types/guards'
 import { CardSize } from '../../types'
@@ -17,7 +17,7 @@ import { CardTemplate } from './CardTemplate'
 
 export interface BaseCardProps extends BoxProps {
   canBeWatered?: boolean
-  card: ICard
+  cardInstance: CardInstance
   cardIdx: number
   disableEnterAnimation?: boolean
   imageScale?: number
@@ -44,19 +44,19 @@ export type WaterCardProps = BaseCardProps
 export type CardProps = CropCardProps | WaterCardProps
 
 const isPropsCropCardProps = (props: CardProps): props is CropCardProps => {
-  return isCropCard(props.card)
+  return isCropCardInstance(props.cardInstance)
 }
 
 const isPropsWaterCardProps = (props: CardProps): props is WaterCardProps => {
-  return isWaterCard(props.card)
+  return isWaterCardInstance(props.cardInstance)
 }
 
 export const CropCard = forwardRef<HTMLDivElement, CropCardProps>(
   function CropCard({ playedCrop, ...props }, ref) {
     return (
       <CardTemplate {...props} ref={ref}>
-        {isCrop(props.card) ? (
-          <CardCropText crop={props.card} playedCrop={playedCrop} />
+        {isCrop(props.cardInstance) ? (
+          <CardCropText crop={props.cardInstance} playedCrop={playedCrop} />
         ) : null}
       </CardTemplate>
     )

--- a/src/ui/components/Card/CardTemplate.tsx
+++ b/src/ui/components/Card/CardTemplate.tsx
@@ -12,8 +12,8 @@ import {
   CardType,
   GameEvent,
   GameState,
-  isCropCard,
-  isWaterCard,
+  isCropCardInstance,
+  isWaterCardInstance,
 } from '../../../game/types'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { useGameRules } from '../../hooks/useGameRules'
@@ -34,7 +34,7 @@ const cropWaterIndicatorOutlineColor = '#0072ff'
 export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
   function CardTemplate(
     {
-      card,
+      cardInstance: card,
       cardIdx,
       playerId,
       children,
@@ -202,7 +202,7 @@ export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
                       canBeWatered &&
                       gameState === GameState.PLAYER_WATERING_CROP &&
                       game.currentPlayerId === playerId &&
-                      isCropCard(card) && {
+                      isCropCardInstance(card) && {
                         filter: `drop-shadow(0px 0px 24px ${cropWaterIndicatorOutlineColor})`,
                       }),
                   },
@@ -250,8 +250,8 @@ export const CardTemplate = React.forwardRef<HTMLDivElement, CardProps>(
                         variant="contained"
                         onClick={() => void handlePlayCard()}
                       >
-                        {isCropCard(card) && 'Play crop'}
-                        {isWaterCard(card) && 'Water a crop'}
+                        {isCropCardInstance(card) && 'Play crop'}
+                        {isWaterCardInstance(card) && 'Water a crop'}
                       </Button>
                     </Typography>
                   </Box>

--- a/src/ui/components/Deck/Deck.tsx
+++ b/src/ui/components/Deck/Deck.tsx
@@ -1,12 +1,9 @@
 import Box, { BoxProps } from '@mui/material/Box'
 import useTheme from '@mui/material/styles/useTheme'
-
 import { MouseEventHandler } from 'react'
 
-import * as cards from '../../../game/cards'
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
-import { assertIsCardId } from '../../../game/types/guards'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { useSelectedCardPosition } from '../../hooks/useSelectedCardPosition'
 import { isSxArray } from '../../type-guards'
@@ -59,21 +56,14 @@ export const Deck = ({
       ]}
       {...rest}
     >
-      {player.deck.map((_, idx, deck) => {
-        // NOTE: Looping backwards through the deck prevents card animation
-        // artifacting (for some reason)
-        const cardId = deck[deck.length - 1 - idx]
-
-        assertIsCardId(cardId)
-
-        const card = cards[cardId]
+      {player.deck.map((cardInstance, idx) => {
         const offset = (deckThicknessPx / player.deck.length) * idx
         const isTopCard = idx === player.deck.length - 1
 
         return (
           <Card
-            key={`${cardId}_${idx}`}
-            card={card}
+            key={cardInstance.instanceId}
+            cardInstance={cardInstance}
             cardIdx={idx}
             playerId={player.id}
             position="absolute"

--- a/src/ui/components/DiscardPile/DiscardPile.stories.tsx
+++ b/src/ui/components/DiscardPile/DiscardPile.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { stubGame } from '../../../test-utils/stubs/game'
+import { carrot, instantiate, pumpkin, water } from '../../../game/cards'
 import { addToDiscardPile } from '../../../game/reducers/add-to-discard-pile'
 import { IGame } from '../../../game/types'
+import { stubGame } from '../../../test-utils/stubs/game'
 
 import {
   DiscardPile,
@@ -41,8 +42,14 @@ export const SelfDiscardPile: Story = {
     cardSize: defaultDiscardPileCardSize,
     discardPileThicknessPx: defaultDiscardPileThicknessPx,
     game: (() => {
-      return ['carrot', 'pumpkin', 'pumpkin', 'water'].reduce(
-        (acc: IGame, cardId) => addToDiscardPile(acc, selfPlayerId, cardId),
+      return [
+        instantiate(carrot),
+        instantiate(pumpkin),
+        instantiate(pumpkin),
+        instantiate(water),
+      ].reduce(
+        (acc: IGame, cardInstance) =>
+          addToDiscardPile(acc, selfPlayerId, cardInstance),
         game
       )
     })(),
@@ -55,8 +62,14 @@ export const OpponentDiscardPile: Story = {
     cardSize: defaultDiscardPileCardSize,
     discardPileThicknessPx: defaultDiscardPileThicknessPx,
     game: (() => {
-      return ['carrot', 'pumpkin', 'pumpkin', 'water'].reduce(
-        (acc: IGame, cardId) => addToDiscardPile(acc, opponentPlayerId, cardId),
+      return [
+        instantiate(carrot),
+        instantiate(pumpkin),
+        instantiate(pumpkin),
+        instantiate(water),
+      ].reduce(
+        (acc: IGame, cardInstance) =>
+          addToDiscardPile(acc, opponentPlayerId, cardInstance),
         game
       )
     })(),

--- a/src/ui/components/DiscardPile/DiscardPile.tsx
+++ b/src/ui/components/DiscardPile/DiscardPile.tsx
@@ -2,10 +2,8 @@ import Box, { BoxProps } from '@mui/material/Box'
 import useTheme from '@mui/material/styles/useTheme'
 import Tooltip from '@mui/material/Tooltip'
 
-import * as cards from '../../../game/cards'
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
-import { assertIsCardId } from '../../../game/types/guards'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { CardSize } from '../../types'
 import { Card } from '../Card'
@@ -50,22 +48,19 @@ export const DiscardPile = ({
       }}
       {...rest}
     >
-      {player.discardPile.map((cardId, idx) => {
-        assertIsCardId(cardId)
-
-        const card = cards[cardId]
+      {player.discardPile.map((cardInstance, idx) => {
         const offset =
           (discardPileThicknessPx / player.discardPile.length) * idx
 
         return (
           <Tooltip
-            key={`${cardId}_${idx}`}
-            title={card.name}
+            key={cardInstance.instanceId}
+            title={cardInstance.name}
             placement="top"
             arrow
           >
             <Card
-              card={card}
+              cardInstance={cardInstance}
               size={cardSize}
               cardIdx={idx}
               playerId={playerId}

--- a/src/ui/components/Field/Field.stories.tsx
+++ b/src/ui/components/Field/Field.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { stubGame } from '../../../test-utils/stubs/game'
 import { updateField } from '../../../game/reducers/update-field'
-import { carrot, pumpkin } from '../../../game/cards'
+import { carrot, instantiate, pumpkin } from '../../../game/cards'
 import { factory } from '../../../game/services/Factory'
 
 import { Field } from './Field'
@@ -27,17 +27,17 @@ const opponentPlayerId = Object.keys(game.table.players)[1]
 
 game = updateField(game, selfPlayerId, {
   crops: [
-    { ...factory.buildPlayedCrop(carrot), waterCards: 1 },
-    { ...factory.buildPlayedCrop(pumpkin), waterCards: 3 },
-    { ...factory.buildPlayedCrop(pumpkin), waterCards: 12 },
+    { ...factory.buildPlayedCrop(instantiate(carrot)), waterCards: 1 },
+    { ...factory.buildPlayedCrop(instantiate(pumpkin)), waterCards: 3 },
+    { ...factory.buildPlayedCrop(instantiate(pumpkin)), waterCards: 12 },
   ],
 })
 
 game = updateField(game, opponentPlayerId, {
   crops: [
-    { ...factory.buildPlayedCrop(carrot), waterCards: 1 },
-    { ...factory.buildPlayedCrop(pumpkin), waterCards: 3 },
-    { ...factory.buildPlayedCrop(pumpkin), waterCards: 12 },
+    { ...factory.buildPlayedCrop(instantiate(carrot)), waterCards: 1 },
+    { ...factory.buildPlayedCrop(instantiate(pumpkin)), waterCards: 3 },
+    { ...factory.buildPlayedCrop(instantiate(pumpkin)), waterCards: 12 },
   ],
 })
 

--- a/src/ui/components/Field/Field.test.tsx
+++ b/src/ui/components/Field/Field.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { factory } from '../../../game/services/Factory'
 import { updateField } from '../../../game/reducers/update-field'
+import { factory } from '../../../game/services/Factory'
+import { stubCarrot, stubPumpkin } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
-import { carrot, pumpkin } from '../../../game/cards'
-
 import { ActorContext } from '../Game/ActorContext'
 
 import {
@@ -19,12 +18,9 @@ import {
 let gameStub = stubGame()
 const opponentPlayerId = Object.keys(gameStub.table.players)[1]
 
-const fieldCrop1 = carrot
-const fieldCrop2 = pumpkin
-
 const cropsStub = [
-  { ...factory.buildPlayedCrop(fieldCrop1), waterCards: 1 },
-  { ...factory.buildPlayedCrop(fieldCrop2), waterCards: 3 },
+  { ...factory.buildPlayedCrop(stubCarrot), waterCards: 1 },
+  { ...factory.buildPlayedCrop(stubPumpkin), waterCards: 3 },
 ]
 
 gameStub = updateField(gameStub, gameStub.sessionOwnerPlayerId, {

--- a/src/ui/components/Field/Field.tsx
+++ b/src/ui/components/Field/Field.tsx
@@ -1,21 +1,19 @@
-import React, { useEffect, useRef, useState } from 'react'
-import { useDebounceCallback, useWindowSize } from 'usehooks-ts'
 import Box, { BoxProps } from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
 import useTheme from '@mui/material/styles/useTheme'
+import React, { useEffect, useRef, useState } from 'react'
+import { useDebounceCallback, useWindowSize } from 'usehooks-ts'
 
-import { PlayedCrop } from '../PlayedCrop'
-import * as cards from '../../../game/cards'
-import { lookup } from '../../../game/services/Lookup'
-import { GameState, IGame, IPlayer } from '../../../game/types'
-import { assertIsCardId } from '../../../game/types/guards'
 import {
   SELECTED_CARD_ELEVATION,
   STANDARD_FIELD_SIZE,
 } from '../../../game/config'
-import { CardSize } from '../../types'
+import { lookup } from '../../../game/services/Lookup'
+import { GameState, IGame, IPlayer } from '../../../game/types'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { useGameRules } from '../../hooks/useGameRules'
+import { CardSize } from '../../types'
+import { PlayedCrop } from '../PlayedCrop'
 
 const deselectedIdx = -1
 const selectedCardYOffset = -25
@@ -168,30 +166,21 @@ export const Field = ({
       >
         {!isSessionOwnerPlayer && emptyCardSlots}
         {crops.map((playedCrop, idx) => {
-          const { id: cardId, waterCards } = playedCrop
+          const { instance: cardInstance } = playedCrop
 
-          assertIsCardId(cardId)
-
-          const card = cards[cardId]
           const isSelected = selectedCardIdx === idx
           const isInBackground =
             selectedCardIdx !== deselectedIdx && !isSelected
 
           return (
-            <Grid
-              key={`${idx}_${cardId}_${waterCards}`}
-              item
-              xs={6}
-              sm={4}
-              md={2}
-            >
+            <Grid key={cardInstance.instanceId} item xs={6} sm={4} md={2}>
               <PlayedCrop
                 aria-label={
                   isSelected ? selectedCardLabel : unselectedCardLabel
                 }
                 tabIndex={0}
                 cropCardProps={{
-                  card,
+                  cardInstance,
                   cardIdx: idx,
                   isInField: true,
                   isFocused: isSelected,

--- a/src/ui/components/Game/Game.stories.tsx
+++ b/src/ui/components/Game/Game.stories.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box'
 import type { Meta, StoryObj } from '@storybook/react'
 import { Mock } from 'vitest'
 
-import { carrot, pumpkin } from '../../../game/cards'
+import { carrot, instantiate, pumpkin } from '../../../game/cards'
 import { stubDeck } from '../../../test-utils/stubs/deck'
 import { stubPlayer } from '../../../test-utils/stubs/players'
 
@@ -44,12 +44,12 @@ const deck = stubDeck()
 // TODO: Move this setup to stubDeck
 for (let i = 0; i < 15; i++) {
   // eslint-disable-next-line functional/immutable-data
-  deck[i] = carrot.id
+  deck[i] = instantiate(carrot)
 }
 
 for (let i = 15; i < 30; i++) {
   // eslint-disable-next-line functional/immutable-data
-  deck[i] = pumpkin.id
+  deck[i] = instantiate(pumpkin)
 }
 
 const player1 = stubPlayer({ id: 'player-1', deck })

--- a/src/ui/components/Hand/Hand.stories.tsx
+++ b/src/ui/components/Hand/Hand.stories.tsx
@@ -6,7 +6,7 @@ import Tooltip from '@mui/material/Tooltip'
 import type { Meta, StoryObj } from '@storybook/react'
 import { useState } from 'react'
 
-import { carrot, pumpkin, water } from '../../../game/cards'
+import { carrot, instantiate, pumpkin, water } from '../../../game/cards'
 import { updatePlayer } from '../../../game/reducers/update-player'
 import { lookup } from '../../../game/services/Lookup'
 import { randomNumber } from '../../../services/RandomNumber'
@@ -14,6 +14,12 @@ import { stubGame } from '../../../test-utils/stubs/game'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { StubShellContext } from '../../test-utils/StubShellContext'
 import { CardSize } from '../../types'
+
+import {
+  stubCarrot,
+  stubPumpkin,
+  stubWater,
+} from '../../../test-utils/stubs/cards'
 
 import { Hand } from './Hand'
 
@@ -35,7 +41,7 @@ const meta = {
       const handleClickAdd = () => {
         setHand([
           ...hand,
-          randomNumber.chooseElement([carrot.id, water.id, pumpkin.id]),
+          randomNumber.chooseElement([stubCarrot, stubWater, stubPumpkin]),
         ])
       }
 
@@ -109,11 +115,17 @@ type Story = StoryObj<typeof meta>
 const baseGame = stubGame()
 
 const gameWithHandOf3 = updatePlayer(baseGame, baseGame.sessionOwnerPlayerId, {
-  hand: [carrot.id, pumpkin.id, water.id],
+  hand: [stubCarrot, stubPumpkin, stubWater],
 })
 
 const gameWithHandOf5 = updatePlayer(baseGame, baseGame.sessionOwnerPlayerId, {
-  hand: [carrot.id, pumpkin.id, water.id, carrot.id, pumpkin.id],
+  hand: [
+    instantiate(carrot),
+    instantiate(pumpkin),
+    instantiate(water),
+    instantiate(carrot),
+    instantiate(pumpkin),
+  ],
 })
 
 export const HandOf3: Story = {

--- a/src/ui/components/Hand/Hand.test.tsx
+++ b/src/ui/components/Hand/Hand.test.tsx
@@ -1,20 +1,26 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { carrot, pumpkin, water } from '../../../game/cards'
+import { instantiate, water } from '../../../game/cards'
 import { updatePlayer } from '../../../game/reducers/update-player'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { StubShellContext } from '../../test-utils/StubShellContext'
 import { cardClassName } from '../Card/CardTemplate'
 import { ActorContext } from '../Game/ActorContext'
 
+import {
+  stubCarrot,
+  stubPumpkin,
+  stubWater,
+} from '../../../test-utils/stubs/cards'
+
 import { getGapPixelWidth, Hand, HandProps } from './Hand'
 
 const baseGame = stubGame()
 
-const handCards = [carrot, pumpkin, water]
+const handCards = [stubCarrot, stubPumpkin, stubWater]
 const game = updatePlayer(baseGame, baseGame.sessionOwnerPlayerId, {
-  hand: handCards.map(({ id }) => id),
+  hand: handCards,
 })
 
 const StubHand = (overrides: Partial<HandProps>) => {
@@ -135,9 +141,9 @@ describe('Hand', () => {
 
     await userEvent.click(card1!)
 
-    const newHand = [...handCards, water]
+    const newHand = [...handCards, instantiate(water)]
     const newGame = updatePlayer(game, game.sessionOwnerPlayerId, {
-      hand: newHand.map(({ id }) => id),
+      hand: newHand,
     })
 
     render(<StubHand game={newGame} />)

--- a/src/ui/components/Hand/Hand.tsx
+++ b/src/ui/components/Hand/Hand.tsx
@@ -2,11 +2,9 @@ import Box, { BoxProps } from '@mui/material/Box'
 import useTheme from '@mui/material/styles/useTheme'
 import React, { useContext, useEffect, useState } from 'react'
 
-import * as cards from '../../../game/cards'
 import { SELECTED_CARD_ELEVATION } from '../../../game/config'
 import { lookup } from '../../../game/services/Lookup'
 import { IGame, IPlayer } from '../../../game/types'
-import { assertIsCardId } from '../../../game/types/guards'
 import { useRejectingTimeout } from '../../../lib/hooks/useRejectingTimeout'
 import { math } from '../../../services/Math'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
@@ -139,10 +137,7 @@ export const Hand = ({
       onKeyDown={handleKeyDown}
       onBlur={handleBlur}
     >
-      {player.hand.map((cardId, idx) => {
-        assertIsCardId(cardId)
-
-        const card = cards[cardId]
+      {player.hand.map((cardInstance, idx) => {
         const gapWidthTotal = gapWidthPx * player.hand.length
         const multipliedGap = math.scaleNumber(
           idx / player.hand.length,
@@ -171,9 +166,9 @@ export const Hand = ({
 
         return (
           <Card
-            key={`${cardId}_${idx}`}
+            key={cardInstance.instanceId}
             disableEnterAnimation
-            card={card}
+            cardInstance={cardInstance}
             cardIdx={idx}
             playerId={playerId}
             size={cardSize}

--- a/src/ui/components/PlayedCrop/PlayedCrop.stories.tsx
+++ b/src/ui/components/PlayedCrop/PlayedCrop.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { carrot } from '../../../game/cards'
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 
 import { PlayedCrop } from './PlayedCrop'
 
@@ -20,11 +20,11 @@ type Story = StoryObj<typeof meta>
 export const PlayedCropCard: Story = {
   args: {
     cropCardProps: {
-      card: carrot,
+      cardInstance: stubCarrot,
       cardIdx: 0,
       playerId: '',
       playedCrop: {
-        id: carrot.id,
+        instance: stubCarrot,
         wasWateredTuringTurn: false,
         waterCards: 1,
       },
@@ -36,11 +36,11 @@ export const PlayedCropCard: Story = {
 export const PlayedCropCardWithExtraWater: Story = {
   args: {
     cropCardProps: {
-      card: carrot,
+      cardInstance: stubCarrot,
       cardIdx: 0,
       playerId: '',
       playedCrop: {
-        id: carrot.id,
+        instance: stubCarrot,
         wasWateredTuringTurn: false,
         waterCards: 5,
       },

--- a/src/ui/components/PlayedCrop/PlayedCrop.test.tsx
+++ b/src/ui/components/PlayedCrop/PlayedCrop.test.tsx
@@ -1,8 +1,8 @@
-import { render } from '@testing-library/react'
 import { screen } from '@testing-library/dom'
+import { render } from '@testing-library/react'
 
-import { carrot } from '../../../game/cards'
 import { IPlayedCrop } from '../../../game/types'
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 import { ActorContext } from '../Game/ActorContext'
 
 import {
@@ -11,15 +11,15 @@ import {
   unfilledWaterIndicatorOpacity,
 } from './PlayedCrop'
 
-const stubCard = carrot
+const stubCardInstance = stubCarrot
 const stubWaterCards = 1
 const stubPlayedCrop: IPlayedCrop = {
-  id: stubCard.id,
+  instance: stubCardInstance,
   wasWateredTuringTurn: false,
   waterCards: stubWaterCards,
 }
-const stubCropCardProps = {
-  card: stubCard,
+const stubCropCardProps: PlayedCropProps['cropCardProps'] = {
+  cardInstance: stubCardInstance,
   playedCrop: stubPlayedCrop,
   cardIdx: 0,
   playerId: '',
@@ -39,14 +39,14 @@ describe('PlayedCrop', () => {
   test('renders played crop card', () => {
     render(<StubCropCard />)
 
-    expect(screen.findByText(stubCard.name))
+    expect(screen.findByText(stubCardInstance.name))
   })
 
   test('renders water indicators', () => {
     render(<StubCropCard />)
 
     expect(screen.getAllByAltText('Water card indicator')).toHaveLength(
-      stubCard.waterToMature
+      stubCardInstance.waterToMature
     )
   })
 

--- a/src/ui/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/ui/components/PlayedCrop/PlayedCrop.tsx
@@ -3,7 +3,7 @@ import Grid from '@mui/material/Grid'
 
 import { useTheme } from '@mui/material'
 
-import { IPlayedCrop, isCropCard } from '../../../game/types'
+import { IPlayedCrop, isCropCardInstance } from '../../../game/types'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { CardSize } from '../../types'
 import { Card, CropCardProps } from '../Card'
@@ -23,10 +23,14 @@ export const PlayedCrop = ({
   cropCardProps: { ref, ...cropCardProps },
   ...props
 }: PlayedCropProps) => {
-  const { card, playedCrop, size = CardSize.MEDIUM } = cropCardProps
+  const {
+    cardInstance: card,
+    playedCrop,
+    size = CardSize.MEDIUM,
+  } = cropCardProps
   const theme = useTheme()
 
-  if (!isCropCard(card)) {
+  if (!isCropCardInstance(card)) {
     throw new InvalidCardError(`${card.id} is not a crop card.`)
   }
 

--- a/src/ui/components/TurnControl/TurnControl.stories.tsx
+++ b/src/ui/components/TurnControl/TurnControl.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { spyOn } from '@storybook/test'
 
-import { carrot } from '../../../game/cards'
 import { updatePlayer } from '../../../game/reducers/update-player'
 import { GameState } from '../../../game/types'
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { stubPlayer1 } from '../../../test-utils/stubs/players'
 import { ActorContext } from '../Game/ActorContext'
@@ -39,7 +39,11 @@ export const WaitingForPlayerSetupActionTurnControl: Story = {
       game = updatePlayer(game, stubPlayer1.id, {
         field: {
           crops: [
-            { id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 },
+            {
+              instance: stubCarrot,
+              wasWateredTuringTurn: false,
+              waterCards: 0,
+            },
           ],
         },
       })

--- a/src/ui/components/TurnControl/TurnControl.test.tsx
+++ b/src/ui/components/TurnControl/TurnControl.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { carrot } from '../../../game/cards'
 import { updateGame } from '../../../game/reducers/update-game'
 import { updatePlayer } from '../../../game/reducers/update-player'
 import { RulesService } from '../../../game/services/Rules'
 import { GameEvent, GameState } from '../../../game/types'
 import { mockSend } from '../../../test-utils/mocks/send'
+import { stubCarrot } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { stubPlayer1 } from '../../../test-utils/stubs/players'
 import * as useGameRulesModule from '../../hooks/useGameRules'
@@ -29,7 +29,9 @@ describe('TurnControl Component', () => {
     let game = stubGame()
     game = updatePlayer(game, stubPlayer1.id, {
       field: {
-        crops: [{ id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 }],
+        crops: [
+          { instance: stubCarrot, wasWateredTuringTurn: false, waterCards: 0 },
+        ],
       },
     })
 
@@ -95,7 +97,9 @@ describe('TurnControl Component', () => {
     let game = stubGame()
     game = updatePlayer(game, stubPlayer1.id, {
       field: {
-        crops: [{ id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 }],
+        crops: [
+          { instance: stubCarrot, wasWateredTuringTurn: false, waterCards: 0 },
+        ],
       },
     })
 
@@ -120,7 +124,9 @@ describe('TurnControl Component', () => {
     let game = stubGame()
     game = updatePlayer(game, stubPlayer1.id, {
       field: {
-        crops: [{ id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 }],
+        crops: [
+          { instance: stubCarrot, wasWateredTuringTurn: false, waterCards: 0 },
+        ],
       },
     })
 
@@ -197,7 +203,9 @@ describe('TurnControl Component', () => {
     let game = stubGame()
     game = updatePlayer(game, stubPlayer1.id, {
       field: {
-        crops: [{ id: carrot.id, wasWateredTuringTurn: false, waterCards: 0 }],
+        crops: [
+          { instance: stubCarrot, wasWateredTuringTurn: false, waterCards: 0 },
+        ],
       },
     })
 


### PR DESCRIPTION
### What this PR does

This PR makes an architectural change to using card instances with stable UUIDs to represent cards in the game. This avoids remounting unrelated cards when rendering Card collections such as the Hand or the Field crops, because now card instances can be deterministically tied to a stable, unique identifier via their `key` prop.

### How this change can be validated

- [ ] Perform regression smoke test
- [ ] Verify that random cards don't remount (as shown by their "popping-in" animation) unexpectedly

### Additional information

- [Before](https://github.com/user-attachments/assets/2d28cfda-ffc0-4dd5-a808-e18d14b473a6)
- [After](https://github.com/user-attachments/assets/29199d24-0080-44c4-a41d-4edcd1954389)
