### PR TITLE
chore(vercel): Allow "skip deploy" in commit messages to prevent preview builds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "stat .nojekyll"
+  "ignoreCommand": "stat .nojekyll || git log -1 --pretty=oneline --abbrev-commit | grep -wq '\\[skip deploy\\]' && exit 0 || exit 1"
 }


### PR DESCRIPTION
### What this PR does

This PR tweaks Vercel configuration to allow `[skip deploy]` in the commit message header to prevent Preview Deployments.

### How this change can be validated

This has been verified in practice:
![Screenshot of cancelled deployments](https://github.com/user-attachments/assets/6369a887-dd68-42b9-ab8f-b8408006da4f)

Additionally, the current commit in this PR has triggered a build.