### PR TITLE
feat(ui): Show player funds

### DIFF
--- a/src/lib/formatting/numbers.ts
+++ b/src/lib/formatting/numbers.ts
@@ -1,0 +1,8 @@
+const numberFormatter = new Intl.NumberFormat(undefined, {
+  style: 'decimal',
+  useGrouping: true, // Enables grouping with commas
+}).format.bind(null)
+
+export const formatNumber = (num: number) => {
+  return numberFormatter(num)
+}

--- a/src/ui/components/Game/Game.tsx
+++ b/src/ui/components/Game/Game.tsx
@@ -87,7 +87,7 @@ const GameCore = ({
         sx={[
           {
             backgroundColor: theme.palette.grey['500'],
-            pt: 3,
+            pt: 1,
             // NOTE: This prevents the hide/show Hand button from obscuring
             // Field cards.
             pb: 10,

--- a/src/ui/components/TurnControl/TurnControl.stories.tsx
+++ b/src/ui/components/TurnControl/TurnControl.stories.tsx
@@ -25,10 +25,6 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const DefaultTurnControl: Story = {
-  args: {},
-}
-
 export const WaitingForPlayerSetupActionTurnControl: Story = {
   args: {},
   decorators: [


### PR DESCRIPTION
### What this PR does

This PR implements indicators for the players' and community funds.

### How this change can be validated

- [ ] Verify that each players' current funds are shown at the top of the page, as well as the community funds.
- [ ] Verify that the player's fund indicators turn red when they reach 10 or less.

### Questions or concerns about this change

### Additional information

[Screencast of player fund indicators](https://github.com/user-attachments/assets/ccaaf021-7ffa-477a-9ca4-876b2386de21)
