### PR TITLE
feat(ui): Implement notification system

### DIFF
--- a/src/ui/components/Field/Field.stories.tsx
+++ b/src/ui/components/Field/Field.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { stubGame } from '../../../test-utils/stubs/game'
-import { updateField } from '../../../game/reducers/update-field'
 import { carrot, instantiate, pumpkin } from '../../../game/cards'
+import { updateField } from '../../../game/reducers/update-field'
 import { factory } from '../../../game/services/Factory'
+import { stubGame } from '../../../test-utils/stubs/game'
+import { StubShellContext } from '../../test-utils/StubShellContext'
 
 import { Field } from './Field'
 
@@ -15,6 +16,15 @@ const meta = {
   },
   tags: ['autodocs'],
   argTypes: {},
+  decorators: [
+    Story => {
+      return (
+        <StubShellContext>
+          <Story />
+        </StubShellContext>
+      )
+    },
+  ],
 } satisfies Meta<typeof Field>
 
 export default meta

--- a/src/ui/components/Field/Field.test.tsx
+++ b/src/ui/components/Field/Field.test.tsx
@@ -6,6 +6,7 @@ import { factory } from '../../../game/services/Factory'
 import { stubCarrot, stubPumpkin } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { ActorContext } from '../Game/ActorContext'
+import { StubShellContext } from '../../test-utils/StubShellContext'
 
 import {
   Field,
@@ -33,13 +34,15 @@ gameStub = updateField(gameStub, opponentPlayerId, {
 
 const StubField = (overrides: Partial<FieldProps>) => {
   return (
-    <ActorContext.Provider>
-      <Field
-        game={gameStub}
-        playerId={gameStub.sessionOwnerPlayerId}
-        {...overrides}
-      />
-    </ActorContext.Provider>
+    <StubShellContext>
+      <ActorContext.Provider>
+        <Field
+          game={gameStub}
+          playerId={gameStub.sessionOwnerPlayerId}
+          {...overrides}
+        />
+      </ActorContext.Provider>
+    </StubShellContext>
   )
 }
 

--- a/src/ui/components/Game/ShellContext.tsx
+++ b/src/ui/components/Game/ShellContext.tsx
@@ -1,4 +1,5 @@
-import { createContext } from 'react'
+import { AlertColor } from '@mui/material/Alert'
+import { createContext, ReactNode } from 'react'
 
 export interface ShellContextProps {
   /**
@@ -7,6 +8,7 @@ export interface ShellContextProps {
   blockingOperation: (fn: () => Promise<void>) => Promise<void>
   isHandInViewport: boolean
   setIsHandInViewport: React.Dispatch<React.SetStateAction<boolean>>
+  showNotification: (message: ReactNode, severity: AlertColor) => void
 }
 
 export const ShellContext = createContext<ShellContextProps>({
@@ -15,6 +17,9 @@ export const ShellContext = createContext<ShellContextProps>({
   },
   isHandInViewport: true,
   setIsHandInViewport: () => {
+    throw new Error('Calling context method outside of ShellContext.Provider')
+  },
+  showNotification: () => {
     throw new Error('Calling context method outside of ShellContext.Provider')
   },
 })

--- a/src/ui/components/Game/Snackbar.tsx
+++ b/src/ui/components/Game/Snackbar.tsx
@@ -1,0 +1,61 @@
+import Alert, { AlertProps } from '@mui/material/Alert'
+import Slide from '@mui/material/Slide'
+import MuiSnackbar from '@mui/material/Snackbar'
+import useTheme from '@mui/material/styles/useTheme'
+import { ReactNode, useCallback, useEffect, useState } from 'react'
+import { useDebounceCallback } from 'usehooks-ts'
+
+export interface SnackbarProps extends Pick<AlertProps, 'severity'> {
+  message: ReactNode
+  onClose: () => void
+}
+
+export const notificationDuration = 3000
+
+export const emptyNotificationMessage = ''
+
+export const Snackbar = ({ message, severity, onClose }: SnackbarProps) => {
+  const theme = useTheme()
+  const [isOpen, setIsOpen] = useState(false)
+  const [previousMessage, setPreviousMessage] =
+    useState<SnackbarProps['message']>(null)
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false)
+    onClose?.()
+  }, [onClose])
+
+  const scheduleSnackbarClose = useDebounceCallback(
+    handleClose,
+    notificationDuration
+  )
+
+  useEffect(() => {
+    if (message !== emptyNotificationMessage) {
+      setPreviousMessage(message)
+      setIsOpen(true)
+
+      scheduleSnackbarClose.cancel()
+      scheduleSnackbarClose()
+    }
+  }, [message, severity, scheduleSnackbarClose])
+
+  return (
+    <MuiSnackbar
+      TransitionComponent={Slide}
+      anchorOrigin={{ horizontal: 'center', vertical: 'bottom' }}
+      onClose={handleClose}
+      open={isOpen}
+      sx={{ bottom: { xs: theme.spacing(11), sm: theme.spacing(2) } }}
+    >
+      <Alert severity={severity} elevation={12} variant="filled">
+        {/*
+          NOTE: previousMessage is shown as fallback content to prevent the
+          Alert from visibly rerendering with empty content when it transitions
+          away.
+          */}
+        {message || previousMessage}
+      </Alert>
+    </MuiSnackbar>
+  )
+}

--- a/src/ui/components/Game/useGame.test.ts
+++ b/src/ui/components/Game/useGame.test.ts
@@ -1,0 +1,248 @@
+import { renderHook } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+
+import { GameState, GameEvent, IPlayerSeed } from '../../../game/types'
+import { useGameRules } from '../../hooks/useGameRules'
+import { stubGame } from '../../../test-utils/stubs/game'
+
+import { ActorContext } from './ActorContext'
+import { useGame } from './useGame'
+import { emptyNotificationMessage } from './Snackbar'
+
+// Mock dependencies
+vi.mock('../../hooks/useGameRules')
+vi.mock('./ActorContext')
+
+describe('useGame', () => {
+  // Mock player seeds and user ID
+  const mockPlayerSeeds: IPlayerSeed[] = [
+    { id: 'player1', deck: [] },
+    { id: 'player2', deck: [] },
+  ]
+  const mockUserPlayerId = 'player1'
+
+  // Mock actor ref
+  // @ts-expect-error Only the relevant properties are mocked
+  const mockActorRef: ReturnType<typeof ActorContext.useActorRef> = {
+    send: vi.fn(),
+    subscribe: vi.fn(),
+  }
+
+  // Mock game rules
+  const mockGame = stubGame({
+    sessionOwnerPlayerId: 'player1',
+    currentPlayerId: 'player1',
+  })
+
+  beforeEach(() => {
+    // Setup mocks
+    vi.mocked(ActorContext.useActorRef).mockReturnValue(mockActorRef)
+    vi.mocked(useGameRules).mockReturnValue({
+      game: mockGame,
+      gameState: GameState.UNINITIALIZED,
+      selectedWaterCardInHandIdx: 0,
+    })
+  })
+
+  it('should initialize game when gameState is UNINITIALIZED', () => {
+    renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockActorRef.send).toHaveBeenCalledWith({
+      type: GameEvent.INIT,
+      playerSeeds: mockPlayerSeeds,
+      userPlayerId: mockUserPlayerId,
+    })
+  })
+
+  it('should not initialize game when gameState is not UNINITIALIZED', () => {
+    vi.mocked(useGameRules).mockReturnValue({
+      game: mockGame,
+      gameState: GameState.PLAYER_WATERING_CROP,
+      selectedWaterCardInHandIdx: 0,
+    })
+
+    renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(mockActorRef.send).not.toHaveBeenCalled()
+  })
+
+  it('should execute blocking operation correctly', async () => {
+    const mockOperation = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    await act(async () => {
+      await result.current.shellContextValue.blockingOperation(mockOperation)
+    })
+
+    expect(mockOperation).toHaveBeenCalled()
+  })
+
+  it('should handle errors in blocking operation', async () => {
+    const mockOperation = vi.fn().mockRejectedValue(new Error('Test error'))
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    await act(async () => {
+      await result.current.shellContextValue.blockingOperation(mockOperation)
+    })
+
+    expect(mockOperation).toHaveBeenCalled()
+    // Should not throw and should complete the operation
+  })
+
+  it('should set isInputBlocked when blocking operation is executing', async () => {
+    const mockOperation = vi.fn().mockImplementation(() => {
+      return new Promise(resolve => {
+        setTimeout(resolve, 100)
+      })
+    })
+
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    expect(result.current.isInputBlocked).toBe(false)
+
+    const operationPromise = act(async () => {
+      await result.current.shellContextValue.blockingOperation(mockOperation)
+    })
+
+    // Check that isInputBlocked is true during operation
+    expect(mockOperation).toHaveBeenCalled()
+
+    await operationPromise
+
+    // Should be false after operation completes
+    expect(result.current.isInputBlocked).toBe(false)
+  })
+
+  it('should set isInputBlocked when not session owner turn', () => {
+    vi.mocked(useGameRules).mockReturnValue({
+      game: { ...mockGame, currentPlayerId: 'player2' },
+      gameState: GameState.UNINITIALIZED,
+      selectedWaterCardInHandIdx: 0,
+    })
+
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    expect(result.current.isInputBlocked).toBe(true)
+  })
+
+  it('should toggle hand visibility', () => {
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    expect(result.current.showHand).toBe(true)
+
+    act(() => {
+      result.current.handleHandVisibilityToggle()
+    })
+
+    expect(result.current.showHand).toBe(false)
+  })
+
+  it('should set isHandDisabled when in PLAYER_WATERING_CROP state', () => {
+    vi.mocked(useGameRules).mockReturnValue({
+      game: mockGame,
+      gameState: GameState.PLAYER_WATERING_CROP,
+      selectedWaterCardInHandIdx: 0,
+    })
+
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    expect(result.current.isHandDisabled).toBe(true)
+  })
+
+  it('should show hand when isHandInViewport is true', () => {
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    expect(result.current.showHand).toBe(true)
+  })
+
+  it('should always show hand when isHandDisabled is true, regardless of isHandInViewport', () => {
+    vi.mocked(useGameRules).mockReturnValue({
+      game: mockGame,
+      gameState: GameState.PLAYER_WATERING_CROP,
+      selectedWaterCardInHandIdx: 0,
+    })
+
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    // First, hide the hand
+    act(() => {
+      result.current.handleHandVisibilityToggle()
+    })
+
+    // Should still be shown because isHandDisabled is true
+    expect(result.current.showHand).toBe(true)
+  })
+
+  it('should update snackbar props when showNotification is called', () => {
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    act(() => {
+      result.current.shellContextValue.showNotification(
+        'Test message',
+        'success'
+      )
+    })
+
+    expect(result.current.snackbarProps.message).toBe('Test message')
+    expect(result.current.snackbarProps.severity).toBe('success')
+  })
+
+  it('should clear snackbar message when onClose is called', () => {
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    act(() => {
+      result.current.shellContextValue.showNotification(
+        'Test message',
+        'success'
+      )
+    })
+
+    expect(result.current.snackbarProps.message).toBe('Test message')
+
+    act(() => {
+      result.current.snackbarProps.onClose()
+    })
+
+    expect(result.current.snackbarProps.message).toBe(emptyNotificationMessage)
+  })
+
+  it('should update isHandInViewport when setIsHandInViewport is called', () => {
+    const { result } = renderHook(() =>
+      useGame({ playerSeeds: mockPlayerSeeds, userPlayerId: mockUserPlayerId })
+    )
+
+    expect(result.current.shellContextValue.isHandInViewport).toBe(true)
+
+    act(() => {
+      result.current.shellContextValue.setIsHandInViewport(false)
+    })
+
+    expect(result.current.shellContextValue.isHandInViewport).toBe(false)
+  })
+})

--- a/src/ui/components/Game/useGame.ts
+++ b/src/ui/components/Game/useGame.ts
@@ -1,0 +1,108 @@
+import { AlertColor } from '@mui/material'
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
+
+import { GameEvent, GameState, IPlayerSeed } from '../../../game/types'
+import { isDebugEnabled } from '../../config/constants'
+import { useGameRules } from '../../hooks/useGameRules'
+
+import { ActorContext } from './ActorContext'
+import { ShellContextProps } from './ShellContext'
+import { emptyNotificationMessage, SnackbarProps } from './Snackbar'
+
+export const useGame = ({
+  playerSeeds,
+  userPlayerId,
+}: {
+  playerSeeds: IPlayerSeed[]
+  userPlayerId: string
+}) => {
+  const actorRef = ActorContext.useActorRef()
+  const { game, gameState } = useGameRules()
+  const [isHandInViewport, setIsHandInViewport] = useState(true)
+
+  useEffect(() => {
+    if (isDebugEnabled) {
+      actorRef.subscribe(snapshot => {
+        if (typeof snapshot.value === 'string') {
+          console.debug(`State: ${snapshot.value}`)
+        }
+      })
+    }
+  }, [actorRef])
+
+  const [isBlockingOperationExecuting, setIsBlockingOperationExecuting] =
+    useState(false)
+
+  useEffect(() => {
+    if (gameState === GameState.UNINITIALIZED) {
+      actorRef.send({ type: GameEvent.INIT, playerSeeds, userPlayerId })
+    }
+  }, [gameState, playerSeeds, userPlayerId, actorRef])
+
+  const blockingOperation: ShellContextProps['blockingOperation'] = useCallback(
+    async fn => {
+      try {
+        setIsBlockingOperationExecuting(true)
+        await fn()
+      } catch (_e) {
+        // Empty
+      } finally {
+        setIsBlockingOperationExecuting(false)
+      }
+    },
+    [setIsBlockingOperationExecuting]
+  )
+
+  const [snackbarProps, setSnackbarProps] = useState<SnackbarProps>({
+    message: '',
+    severity: 'info',
+    onClose: () => {
+      setSnackbarProps(prev => ({
+        ...prev,
+        message: emptyNotificationMessage,
+      }))
+    },
+  })
+
+  const showNotification = useCallback(
+    (message: ReactNode, severity: AlertColor) => {
+      if (isDebugEnabled) {
+        console.debug(`Notification: ${String(message)}`)
+      }
+
+      setSnackbarProps(prev => ({ ...prev, message, severity }))
+    },
+    []
+  )
+
+  const shellContextValue: ShellContextProps = useMemo(
+    () => ({
+      blockingOperation,
+      isHandInViewport,
+      setIsHandInViewport,
+      showNotification,
+    }),
+    [blockingOperation, isHandInViewport, setIsHandInViewport, showNotification]
+  )
+
+  const isSessionOwnersTurn = game.sessionOwnerPlayerId === game.currentPlayerId
+  const isInputBlocked = isBlockingOperationExecuting || !isSessionOwnersTurn
+
+  const handleHandVisibilityToggle = () => {
+    setIsHandInViewport(prev => !prev)
+  }
+
+  const isHandDisabled = [GameState.PLAYER_WATERING_CROP].includes(gameState)
+
+  const showHand = isHandInViewport || isHandDisabled
+
+  return {
+    game,
+    handleHandVisibilityToggle,
+    isHandDisabled,
+    isInputBlocked,
+    shellContextValue,
+    showHand,
+    snackbarProps,
+  }
+}

--- a/src/ui/components/PlayedCrop/PlayedCrop.stories.tsx
+++ b/src/ui/components/PlayedCrop/PlayedCrop.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { stubCarrot } from '../../../test-utils/stubs/cards'
+import { StubShellContext } from '../../test-utils/StubShellContext'
 
 import { PlayedCrop } from './PlayedCrop'
 
@@ -12,6 +13,15 @@ const meta = {
   },
   tags: ['autodocs'],
   argTypes: {},
+  decorators: [
+    Story => {
+      return (
+        <StubShellContext>
+          <Story />
+        </StubShellContext>
+      )
+    },
+  ],
 } satisfies Meta<typeof PlayedCrop>
 
 export default meta

--- a/src/ui/components/PlayedCrop/PlayedCrop.test.tsx
+++ b/src/ui/components/PlayedCrop/PlayedCrop.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react'
 
 import { IPlayedCrop } from '../../../game/types'
 import { stubCarrot } from '../../../test-utils/stubs/cards'
+import { StubShellContext } from '../../test-utils/StubShellContext'
 import { ActorContext } from '../Game/ActorContext'
 
 import {
@@ -26,13 +27,15 @@ const stubCropCardProps: PlayedCropProps['cropCardProps'] = {
 }
 
 const StubCropCard = (overrides: Partial<PlayedCropProps> = {}) => (
-  <ActorContext.Provider>
-    <PlayedCrop
-      cropCardProps={stubCropCardProps}
-      isInBackground={false}
-      {...overrides}
-    />
-  </ActorContext.Provider>
+  <StubShellContext>
+    <ActorContext.Provider>
+      <PlayedCrop
+        cropCardProps={stubCropCardProps}
+        isInBackground={false}
+        {...overrides}
+      />
+    </ActorContext.Provider>
+  </StubShellContext>
 )
 
 describe('PlayedCrop', () => {

--- a/src/ui/components/PlayedCrop/PlayedCrop.tsx
+++ b/src/ui/components/PlayedCrop/PlayedCrop.tsx
@@ -1,19 +1,18 @@
 import Box, { BoxProps } from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
+import useTheme from '@mui/material/styles/useTheme'
 
-import { useTheme } from '@mui/material'
-
+import { InvalidCardError } from '../../../game/services/Rules/errors'
 import { IPlayedCrop, isCropCardInstance } from '../../../game/types'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { CardSize } from '../../types'
 import { Card, CropCardProps } from '../Card'
-import { Image } from '../Image'
-import { cards as cardImages } from '../../img'
-import { InvalidCardError } from '../../../game/services/Rules/errors'
+
+import { WaterIndicator } from './WaterIndicator'
 
 export interface PlayedCropProps extends BoxProps {
-  isInBackground: boolean
   cropCardProps: CropCardProps & { playedCrop: IPlayedCrop }
+  isInBackground: boolean
 }
 
 export const unfilledWaterIndicatorOpacity = 0.25
@@ -53,22 +52,21 @@ export const PlayedCrop = ({
         {new Array(waterIconsToRender).fill(null).map((_, idx) => {
           let opacity = 1
 
+          const isFilled = idx < playedCrop.waterCards
+
           if (isInBackground) {
             opacity = 0
-          } else if (idx >= playedCrop.waterCards) {
+          } else if (!isFilled) {
             opacity = unfilledWaterIndicatorOpacity
           }
 
           return (
             <Grid key={idx} item sx={{ pt: `${theme.spacing(0)} !important` }}>
-              <Image
-                src={cardImages.water}
-                alt="Water card indicator"
-                sx={{
-                  imageRendering: 'pixelated',
-                  opacity,
-                  transition: theme.transitions.create(['opacity']),
-                }}
+              <WaterIndicator
+                cardInstance={playedCrop.instance}
+                isFilled={isFilled}
+                opacity={opacity}
+                playerId={cropCardProps.playerId}
               />
             </Grid>
           )

--- a/src/ui/components/PlayedCrop/WaterIndicator.test.tsx
+++ b/src/ui/components/PlayedCrop/WaterIndicator.test.tsx
@@ -1,0 +1,143 @@
+import { funAnimalName } from 'fun-animal-names'
+
+import { render, screen } from '@testing-library/react'
+
+import { GameState } from '../../../game/types'
+import { stubCarrot } from '../../../test-utils/stubs/cards'
+import { stubGame } from '../../../test-utils/stubs/game'
+import { useGameRules } from '../../hooks/useGameRules'
+
+import {
+  mockShowNotification,
+  StubShellContext,
+} from '../../test-utils/StubShellContext'
+
+import { stubPlayer1, stubPlayer2 } from '../../../test-utils/stubs/players'
+
+import {
+  unfilledWaterIndicatorOpacity,
+  WaterIndicator,
+  WaterIndicatorProps,
+} from './WaterIndicator'
+
+// Mock dependencies
+vi.mock('@mui/material/styles/useTheme', () => ({
+  default: vi.fn(() => ({
+    transitions: {
+      create: vi.fn(() => 'mocked-transition'),
+    },
+  })),
+}))
+
+vi.mock('fun-animal-names', () => ({
+  funAnimalName: vi.fn(() => 'Silly Rhino'),
+}))
+
+vi.mock('../../hooks/useGameRules', () => ({
+  useGameRules: vi.fn(),
+}))
+
+vi.mock('../../img', () => ({
+  cards: {
+    water: '/path/to/water-image.png',
+  },
+}))
+
+const defaultProps: WaterIndicatorProps = {
+  cardInstance: stubCarrot,
+  isFilled: false,
+  opacity: unfilledWaterIndicatorOpacity,
+  playerId: stubPlayer1.id,
+}
+
+const StubWaterfallIndicator = (overrides: Partial<WaterIndicatorProps>) => {
+  return (
+    <StubShellContext>
+      <WaterIndicator {...defaultProps} {...overrides} />
+    </StubShellContext>
+  )
+}
+
+describe('WaterIndicator', () => {
+  const mockGameRules: ReturnType<typeof useGameRules> = {
+    game: stubGame({
+      currentPlayerId: stubPlayer1.id,
+      sessionOwnerPlayerId: stubPlayer1.id,
+    }),
+    gameState: GameState.PLAYER_WATERING_CROP,
+    selectedWaterCardInHandIdx: 0,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Set up mocks
+    vi.mocked(useGameRules).mockReturnValue(mockGameRules)
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders the water indicator with correct props', () => {
+    render(<StubWaterfallIndicator />)
+
+    const image = screen.getByAltText('Water card indicator')
+    expect(image).toHaveStyle(`opacity: ${unfilledWaterIndicatorOpacity}`)
+  })
+
+  it('applies custom opacity when provided', () => {
+    const customOpacity = 0.75
+
+    render(<StubWaterfallIndicator opacity={customOpacity} />)
+
+    const image = screen.getByAltText('Water card indicator')
+    expect(image).toHaveStyle(`opacity: ${customOpacity}`)
+  })
+
+  it('shows notification when plant is watered by current player who is also session owner', () => {
+    render(
+      <StubShellContext>
+        <WaterIndicator {...defaultProps} isFilled={true} />
+      </StubShellContext>
+    )
+
+    expect(mockShowNotification).toHaveBeenCalledWith(
+      'You watered your Carrot',
+      'info'
+    )
+  })
+
+  it('shows different notification when plant is watered by another player', () => {
+    const otherPlayerMockGameRules = {
+      ...mockGameRules,
+      game: stubGame({
+        currentPlayerId: stubPlayer2.id,
+        sessionOwnerPlayerId: stubPlayer1.id,
+      }),
+    }
+
+    vi.mocked(useGameRules).mockReturnValue(otherPlayerMockGameRules)
+
+    render(<StubWaterfallIndicator isFilled={true} playerId={stubPlayer2.id} />)
+
+    expect(funAnimalName).toHaveBeenCalledWith(stubPlayer2.id)
+    expect(mockShowNotification).toHaveBeenCalledWith(
+      'Silly Rhino watered their Carrot',
+      'info'
+    )
+  })
+
+  it('does not show notification when isFilled is false', () => {
+    render(<StubWaterfallIndicator isFilled={false} />)
+
+    expect(mockShowNotification).not.toHaveBeenCalled()
+  })
+
+  it('uses theme transitions for opacity', () => {
+    render(<StubWaterfallIndicator />)
+
+    const image = screen.getByAltText('Water card indicator')
+    expect(image).toHaveStyle('transition: mocked-transition')
+  })
+})

--- a/src/ui/components/PlayedCrop/WaterIndicator.tsx
+++ b/src/ui/components/PlayedCrop/WaterIndicator.tsx
@@ -1,0 +1,61 @@
+import useTheme from '@mui/material/styles/useTheme'
+import { funAnimalName } from 'fun-animal-names'
+import { useContext, useEffect } from 'react'
+
+import * as cards from '../../../game/cards'
+import { CardInstance, IPlayer } from '../../../game/types'
+import { assertIsCardId } from '../../../game/types/guards'
+import { useGameRules } from '../../hooks/useGameRules'
+import { cards as cardImages } from '../../img'
+import { ShellContext } from '../Game/ShellContext'
+import { Image } from '../Image'
+
+export const unfilledWaterIndicatorOpacity = 0.25
+
+export interface WaterIndicatorProps {
+  cardInstance: CardInstance
+  isFilled: boolean
+  opacity: number
+  playerId: IPlayer['id']
+}
+
+export const WaterIndicator = ({
+  cardInstance,
+  isFilled,
+  opacity,
+  playerId,
+}: WaterIndicatorProps) => {
+  const theme = useTheme()
+  const { showNotification } = useContext(ShellContext)
+  const { game } = useGameRules()
+  const { sessionOwnerPlayerId } = game
+
+  assertIsCardId(cardInstance.id)
+
+  const card = cards[cardInstance.id]
+
+  useEffect(() => {
+    if (isFilled) {
+      if (playerId === sessionOwnerPlayerId) {
+        showNotification(`You watered your ${card.name}`, 'info')
+      } else {
+        showNotification(
+          `${funAnimalName(playerId)} watered their ${card.name}`,
+          'info'
+        )
+      }
+    }
+  }, [playerId, card, showNotification, isFilled, sessionOwnerPlayerId])
+
+  return (
+    <Image
+      src={cardImages.water}
+      alt="Water card indicator"
+      sx={{
+        imageRendering: 'pixelated',
+        opacity,
+        transition: theme.transitions.create(['opacity']),
+      }}
+    />
+  )
+}

--- a/src/ui/config/constants.ts
+++ b/src/ui/config/constants.ts
@@ -1,0 +1,3 @@
+export const isDebugEnabled =
+  import.meta.env.DEV ||
+  new URLSearchParams(window.location.search).has('debug')

--- a/src/ui/test-utils/StubShellContext.tsx
+++ b/src/ui/test-utils/StubShellContext.tsx
@@ -9,6 +9,9 @@ import {
 
 import { isStorybook } from './isStorybook'
 
+export const mockShowNotification =
+  typeof vi === 'undefined' ? () => {} : vi.fn()
+
 export const StubShellContext = ({
   children,
   // NOTE: isStorybook MUST be cast with Boolean() as part of a workaround for
@@ -17,7 +20,7 @@ export const StubShellContext = ({
   /**
    * This needs to be set to false when used in Storybook stories.
    */
-  useVitestMocks = Boolean(isStorybook),
+  useVitestMocks = !isStorybook,
   ...overrides
 }: {
   children: ReactNode
@@ -29,6 +32,7 @@ export const StubShellContext = ({
       blockingOperation: useVitestMocks ? vi.fn() : () => Promise.resolve(),
       isHandInViewport: true,
       setIsHandInViewport: useVitestMocks ? vi.fn() : () => {},
+      showNotification: mockShowNotification,
       ...overrides,
     }),
     [overrides, useVitestMocks]

--- a/src/ui/test-utils/isStorybook.tsx
+++ b/src/ui/test-utils/isStorybook.tsx
@@ -1,4 +1,4 @@
 // NOTE: This needs to be in a separate file as part of a workaround for this
 // issue:
 // https://github.com/storybookjs/builder-vite/issues/570#issuecomment-1824504498
-export const isStorybook = Boolean(import.meta.env.IS_STORYBOOK)
+export const isStorybook = Boolean(import.meta.env.STORYBOOK)

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,7 +4,7 @@
 // NOTE: See https://vite.dev/guide/env-and-mode#intellisense-for-typescript
 
 interface ImportMetaEnv {
-  IS_STORYBOOK?: string
+  STORYBOOK?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
### What this PR does

This PR implements a general purpose notification system for the UI. It also shows notifications when players water their crops.

### How this change can be validated

- [ ] Water a crop and verify that an appropriate message is shown at the bottom of the screen
- [ ] Have the bot player water a crop and verify that an appropriate message is shown at the bottom of the screen

### Additional information

[Screencast of notification system](https://github.com/user-attachments/assets/5302ffd5-e65c-475e-9de1-8f5a5789629e)
