### PR TITLE
feat(game): Implement support for sparse fields

### DIFF
--- a/src/game/reducers/add-crop-to-field/index.test.ts
+++ b/src/game/reducers/add-crop-to-field/index.test.ts
@@ -1,4 +1,4 @@
-import { stubCarrot } from '../../../test-utils/stubs/cards'
+import { stubCarrot, stubPumpkin } from '../../../test-utils/stubs/cards'
 import { stubField } from '../../../test-utils/stubs/field'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { STANDARD_FIELD_SIZE } from '../../config'
@@ -17,6 +17,23 @@ describe('addCropToField', () => {
     const newGame = addCropToField(game, player1Id, playedCrop)
 
     expect(newGame.table.players[player1Id].field.crops).toEqual([playedCrop])
+  })
+
+  test('adds crop to empty slot in sparse field', () => {
+    const game = stubGame()
+    const [player1Id] = Object.keys(game.table.players)
+    const playedCrop = factory.buildPlayedCrop(stubCarrot)
+    const insertedCrop = factory.buildPlayedCrop(stubPumpkin)
+
+    // Initialize field with some empty plots (undefined values)
+    const initialCrops = [playedCrop, undefined, playedCrop, undefined]
+    const sparseField = stubField({ crops: initialCrops })
+    const gameWithSparseField = updateField(game, player1Id, sparseField)
+
+    const newGame = addCropToField(gameWithSparseField, player1Id, insertedCrop)
+
+    const expectedCrops = [playedCrop, insertedCrop, playedCrop, undefined]
+    expect(newGame.table.players[player1Id].field.crops).toEqual(expectedCrops)
   })
 
   test('throws an error if field is full', () => {

--- a/src/game/reducers/add-crop-to-field/index.ts
+++ b/src/game/reducers/add-crop-to-field/index.ts
@@ -1,3 +1,4 @@
+import { array } from '../../../services/Array'
 import { STANDARD_FIELD_SIZE } from '../../config'
 import { FieldFullError } from '../../services/Rules/errors'
 import { IGame, IPlayedCrop, IPlayer } from '../../types'
@@ -9,15 +10,23 @@ export const addCropToField = (
   newCrop: IPlayedCrop
 ) => {
   const { field } = game.table.players[playerId]
-  const { crops } = field
+  let { crops } = field
 
-  if (crops.length >= STANDARD_FIELD_SIZE) {
+  const fullPlots = crops.filter(Boolean)
+
+  if (fullPlots.length >= STANDARD_FIELD_SIZE) {
     throw new FieldFullError(playerId)
   }
 
-  const newCrops = [...crops, newCrop]
+  const emptyPlotIdx = crops.findIndex(crop => crop === undefined)
 
-  game = updateField(game, playerId, { crops: newCrops })
+  if (emptyPlotIdx === -1) {
+    crops = [...crops, newCrop]
+  } else {
+    crops = array.replaceAt(crops, emptyPlotIdx, newCrop)
+  }
+
+  game = updateField(game, playerId, { crops })
 
   return game
 }

--- a/src/game/reducers/harvest-crop/index.test.ts
+++ b/src/game/reducers/harvest-crop/index.test.ts
@@ -28,7 +28,7 @@ describe('harvestCrop', () => {
     game = harvestCrop(game, stubPlayer1.id, 0)
 
     expect(game.table.communityFund).toEqual(initialCommunityFund - saleValue)
-    expect(game.table.players[stubPlayer1.id].field.crops.length).toBe(0)
+    expect(game.table.players[stubPlayer1.id].field.crops).toEqual([undefined])
     expect(game.table.players[stubPlayer1.id].funds).toBe(
       initialPlayerFunds + saleValue
     )

--- a/src/game/reducers/move-from-field-to-discard-pile/index.test.ts
+++ b/src/game/reducers/move-from-field-to-discard-pile/index.test.ts
@@ -1,4 +1,4 @@
-import { stubCarrot } from '../../../test-utils/stubs/cards'
+import { stubCarrot, stubPumpkin } from '../../../test-utils/stubs/cards'
 import { stubGame } from '../../../test-utils/stubs/game'
 import { stubPlayer1 } from '../../../test-utils/stubs/players'
 import { factory } from '../../services/Factory'
@@ -15,12 +15,30 @@ describe('moveFromFieldToDiscardPile', () => {
       factory.buildPlayedCrop(stubCarrot)
     const newGame = moveFromFieldToDiscardPile(game, stubPlayer1.id, 0)
 
-    expect(newGame.table.players[stubPlayer1.id].field.crops).toEqual(
-      game.table.players[stubPlayer1.id].field.crops.slice(1)
-    )
+    expect(newGame.table.players[stubPlayer1.id].field.crops).toEqual([
+      undefined,
+    ])
 
     expect(newGame.table.players[stubPlayer1.id].discardPile).toEqual([
       stubCarrot,
+    ])
+  })
+
+  test('supports sparse fields', () => {
+    const game = stubGame()
+
+    const playedCarrot = factory.buildPlayedCrop(stubCarrot)
+    const playedPumpkin = factory.buildPlayedCrop(stubPumpkin)
+
+    // eslint-disable-next-line functional/immutable-data
+    game.table.players[stubPlayer1.id].field.crops[0] = playedCarrot
+    // eslint-disable-next-line functional/immutable-data
+    game.table.players[stubPlayer1.id].field.crops[1] = playedPumpkin
+    const newGame = moveFromFieldToDiscardPile(game, stubPlayer1.id, 0)
+
+    expect(newGame.table.players[stubPlayer1.id].field.crops).toEqual([
+      undefined,
+      playedPumpkin,
     ])
   })
 

--- a/src/game/reducers/move-from-field-to-discard-pile/index.ts
+++ b/src/game/reducers/move-from-field-to-discard-pile/index.ts
@@ -25,9 +25,10 @@ export const moveFromFieldToDiscardPile = (
     throw new InvalidCardIndexError(cardIdx, playerId)
   }
 
-  const newCrops = array.removeAt(field.crops, cardIdx)
+  let { crops } = field
+  crops = array.replaceAt(crops, cardIdx, undefined)
 
-  game = updateField(game, playerId, { crops: newCrops })
+  game = updateField(game, playerId, { crops })
   game = addToDiscardPile(game, playerId, playedCrop.instance)
 
   return game

--- a/src/game/reducers/start-turn/index.test.ts
+++ b/src/game/reducers/start-turn/index.test.ts
@@ -7,7 +7,7 @@ import { carrot, instantiate } from '../../cards'
 import { DECK_SIZE, STANDARD_TAX_AMOUNT } from '../../config'
 import { updatePlayer } from '../../reducers/update-player'
 import { factory } from '../../services/Factory'
-import { ICard, IGame, IPlayedCrop, IPlayer } from '../../types'
+import { ICard, IField, IGame, IPlayedCrop, IPlayer } from '../../types'
 
 import { startTurn } from '.'
 
@@ -101,5 +101,30 @@ describe('startTurn', () => {
         { instance: carrot3, wasWateredTuringTurn: false, waterCards: 1 },
       ]
     )
+  })
+
+  test('skips over empty field plots', () => {
+    const carrot1 = instantiate(carrot)
+    const carrot2 = instantiate(carrot)
+
+    let newGame = updatePlayer(game, player1Id, {
+      field: {
+        crops: [
+          { instance: carrot1, wasWateredTuringTurn: true, waterCards: 1 },
+          undefined,
+          { instance: carrot2, wasWateredTuringTurn: true, waterCards: 1 },
+        ],
+      },
+    })
+
+    newGame = startTurn(newGame, player1Id)
+
+    expect(newGame.table.players[player1Id].field.crops).toEqual<
+      IField['crops']
+    >([
+      { instance: carrot1, wasWateredTuringTurn: false, waterCards: 1 },
+      undefined,
+      { instance: carrot2, wasWateredTuringTurn: false, waterCards: 1 },
+    ])
   })
 })

--- a/src/game/reducers/start-turn/index.ts
+++ b/src/game/reducers/start-turn/index.ts
@@ -14,7 +14,13 @@ export const startTurn = (game: IGame, playerId: IPlayer['id']): IGame => {
 
   game = drawCard(game, playerId)
 
-  for (let i = 0; i < game.table.players[playerId].field.crops.length; i++) {
+  const crops = game.table.players[playerId].field.crops
+
+  for (let i = 0; i < crops.length; i++) {
+    if (crops[i] === undefined) {
+      continue
+    }
+
     game = updatePlayedCrop(game, playerId, i, { wasWateredTuringTurn: false })
   }
 

--- a/src/game/services/BotLogic/index.ts
+++ b/src/game/services/BotLogic/index.ts
@@ -50,7 +50,7 @@ export class BotLogicService {
 
       const plantedCrop = crops[i]
 
-      if (isCropCardInstance(plantedCrop.instance)) {
+      if (plantedCrop && isCropCardInstance(plantedCrop.instance)) {
         if (
           plantedCrop.waterCards < plantedCrop.instance.waterToMature &&
           plantedCrop.wasWateredTuringTurn === false
@@ -73,7 +73,7 @@ export class BotLogicService {
     for (let i = 0; i < crops.length; i++) {
       const plantedCrop = crops[i]
 
-      if (isCropCardInstance(plantedCrop.instance)) {
+      if (plantedCrop && isCropCardInstance(plantedCrop.instance)) {
         if (plantedCrop.waterCards >= plantedCrop.instance.waterToMature) {
           fieldCropIdxsToHarvest = [...fieldCropIdxsToHarvest, i]
         }

--- a/src/game/services/Rules/index.test.ts
+++ b/src/game/services/Rules/index.test.ts
@@ -595,7 +595,7 @@ describe('createGameStateMachine', () => {
         expect(value).toBe(GameState.WAITING_FOR_PLAYER_TURN_ACTION)
         expect(gameResult.currentPlayerId).toBe(player1.id)
         expect(gameResult.table.players[player2.id].field.crops).toEqual<
-          IPlayedCrop[]
+          IField['crops']
         >(resultingFieldCrops)
         expect(gameResult.table.players[player2.id].hand).toEqual(resultingHand)
         expect(gameResult.table.players[player2.id].deck).toEqual(resultingDeck)
@@ -627,7 +627,7 @@ describe('createGameStateMachine', () => {
             waterCards: carrot.waterToMature,
           },
         ],
-        resultingFieldCrops: [],
+        resultingFieldCrops: [undefined],
         resultingDiscardPile: [stubCarrot],
       },
 
@@ -645,9 +645,8 @@ describe('createGameStateMachine', () => {
             waterCards: 0,
           },
         ],
-        // TODO: Support sparse arrays in IField['crops'] so unrelated cards
-        // aren't shifted
         resultingFieldCrops: [
+          undefined,
           // NOTE: This is the previously unwatered, unharvestable crop
           {
             instance: stubCarrot,
@@ -686,7 +685,7 @@ describe('createGameStateMachine', () => {
         expect(value).toBe(GameState.WAITING_FOR_PLAYER_TURN_ACTION)
         expect(gameResult.currentPlayerId).toBe(player1.id)
         expect(gameResult.table.players[player2.id].field.crops).toEqual<
-          IPlayedCrop[]
+          IField['crops']
         >(resultingFieldCrops)
       }
     )

--- a/src/game/services/Rules/state-machine/performingBotCropHarvestingState.ts
+++ b/src/game/services/Rules/state-machine/performingBotCropHarvestingState.ts
@@ -28,7 +28,7 @@ export const performingBotCropHarvestingState: RulesMachineConfig['states'] = {
         const plantedCrop =
           game.table.players[currentPlayerId].field.crops[cropCardIdxToHarvest]
 
-        assertIsPlayedCrop(plantedCrop)
+        assertIsPlayedCrop(plantedCrop, cropCardIdxToHarvest)
 
         game = harvestCrop(game, currentPlayerId, cropCardIdxToHarvest)
 

--- a/src/game/services/Rules/state-machine/performingBotCropHarvestingState.ts
+++ b/src/game/services/Rules/state-machine/performingBotCropHarvestingState.ts
@@ -1,7 +1,7 @@
 import { enqueueActions } from 'xstate'
 
 import { GameEvent, GameState, ShellNotification } from '../../../types'
-import { assertCurrentPlayer } from '../../../types/guards'
+import { assertCurrentPlayer, assertIsPlayedCrop } from '../../../types/guards'
 import { harvestCrop } from '../../../reducers/harvest-crop'
 
 import { RulesMachineConfig } from './types'
@@ -27,6 +27,8 @@ export const performingBotCropHarvestingState: RulesMachineConfig['states'] = {
 
         const plantedCrop =
           game.table.players[currentPlayerId].field.crops[cropCardIdxToHarvest]
+
+        assertIsPlayedCrop(plantedCrop)
 
         game = harvestCrop(game, currentPlayerId, cropCardIdxToHarvest)
 

--- a/src/game/services/Rules/state-machine/performingBotCropWateringState.ts
+++ b/src/game/services/Rules/state-machine/performingBotCropWateringState.ts
@@ -45,7 +45,7 @@ export const performingBotCropWateringState: RulesMachineConfig['states'] = {
         const playedCrop =
           game.table.players[currentPlayerId].field.crops[cropIdxInFieldToWater]
 
-        assertIsPlayedCrop(playedCrop)
+        assertIsPlayedCrop(playedCrop, cropIdxInFieldToWater)
 
         const updatedPlayedCrop: IPlayedCrop = {
           ...playedCrop,

--- a/src/game/services/Rules/state-machine/performingBotCropWateringState.ts
+++ b/src/game/services/Rules/state-machine/performingBotCropWateringState.ts
@@ -8,7 +8,7 @@ import {
   IPlayedCrop,
   isWaterCardInstance,
 } from '../../../types'
-import { assertCurrentPlayer } from '../../../types/guards'
+import { assertCurrentPlayer, assertIsPlayedCrop } from '../../../types/guards'
 import { GameStateCorruptError } from '../errors'
 
 import { RulesMachineConfig } from './types'
@@ -44,6 +44,8 @@ export const performingBotCropWateringState: RulesMachineConfig['states'] = {
 
         const playedCrop =
           game.table.players[currentPlayerId].field.crops[cropIdxInFieldToWater]
+
+        assertIsPlayedCrop(playedCrop)
 
         const updatedPlayedCrop: IPlayedCrop = {
           ...playedCrop,

--- a/src/game/services/Rules/state-machine/playerWateringCropState.ts
+++ b/src/game/services/Rules/state-machine/playerWateringCropState.ts
@@ -3,6 +3,7 @@ import { enqueueActions } from 'xstate'
 import { moveFromHandToDiscardPile } from '../../../reducers/move-from-hand-to-discard-pile'
 import { updatePlayedCrop } from '../../../reducers/update-played-crop'
 import { GameEvent, GameState, IPlayedCrop } from '../../../types'
+import { assertIsPlayedCrop } from '../../../types/guards'
 import { defaultSelectedWaterCardInHandIdx } from '../constants'
 
 import { RulesMachineConfig } from './types'
@@ -43,6 +44,8 @@ export const playerWateringCropState: RulesMachineConfig['states'] = {
 
               const playedCrop =
                 game.table.players[playerId].field.crops[cropIdxInFieldToWater]
+
+              assertIsPlayedCrop(playedCrop)
 
               const newPlayedCrop: IPlayedCrop = {
                 ...playedCrop,

--- a/src/game/services/Rules/state-machine/playerWateringCropState.ts
+++ b/src/game/services/Rules/state-machine/playerWateringCropState.ts
@@ -45,7 +45,7 @@ export const playerWateringCropState: RulesMachineConfig['states'] = {
               const playedCrop =
                 game.table.players[playerId].field.crops[cropIdxInFieldToWater]
 
-              assertIsPlayedCrop(playedCrop)
+              assertIsPlayedCrop(playedCrop, cropIdxInFieldToWater)
 
               const newPlayedCrop: IPlayedCrop = {
                 ...playedCrop,

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -119,9 +119,10 @@ export function assertStringIsGameState(str: string): asserts str is GameState {
 }
 
 export function assertIsPlayedCrop(
-  plotContents: IField['crops'][0]
+  plotContents: IField['crops'][0],
+  fieldCropIdx: number
 ): asserts plotContents is IPlayedCrop {
   if (plotContents === undefined) {
-    throw new TypeError(`plotContents is undefined`)
+    throw new TypeError(`Field plot at position ${fieldCropIdx} is undefined`)
   }
 }

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -5,6 +5,7 @@ import {
   ICrop,
   IField,
   IGame,
+  IPlayedCrop,
   IPlayer,
   ITable,
 } from '../'
@@ -107,12 +108,20 @@ export function assertCurrentPlayer(
   currentPlayerId: string | null
 ): asserts currentPlayerId is string {
   if (currentPlayerId === null) {
-    throw new TypeError('[TypeError] currentPlayerId must not be null')
+    throw new TypeError('currentPlayerId must not be null')
   }
 }
 
 export function assertStringIsGameState(str: string): asserts str is GameState {
   if (!(str in GameState)) {
     throw new TypeError(`${str} is not a GameState`)
+  }
+}
+
+export function assertIsPlayedCrop(
+  plotContents: IField['crops'][0]
+): asserts plotContents is IPlayedCrop {
+  if (plotContents === undefined) {
+    throw new TypeError(`plotContents is undefined`)
   }
 }

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -115,7 +115,7 @@ export const isWaterCardInstance = (
 }
 
 export interface IField {
-  readonly crops: IPlayedCrop[]
+  readonly crops: (IPlayedCrop | undefined)[]
 }
 
 export interface IPlayer {

--- a/src/services/Array/index.test.ts
+++ b/src/services/Array/index.test.ts
@@ -15,14 +15,6 @@ describe('ArrayService', () => {
     })
   })
 
-  describe('insertAt', () => {
-    test('inserts an element into an array', () => {
-      const arr = array.insertAt([1, 2, 3], 1, 4)
-
-      expect(arr).toEqual([1, 4, 2, 3])
-    })
-  })
-
   describe('replaceAt', () => {
     test('replaces an element in an array', () => {
       const arr = array.replaceAt([1, 2, 3], 1, 4)

--- a/src/services/Array/index.test.ts
+++ b/src/services/Array/index.test.ts
@@ -14,4 +14,20 @@ describe('ArrayService', () => {
       }).toThrow()
     })
   })
+
+  describe('insertAt', () => {
+    test('inserts an element into an array', () => {
+      const arr = array.insertAt([1, 2, 3], 1, 4)
+
+      expect(arr).toEqual([1, 4, 2, 3])
+    })
+  })
+
+  describe('replaceAt', () => {
+    test('replaces an element in an array', () => {
+      const arr = array.replaceAt([1, 2, 3], 1, 4)
+
+      expect(arr).toEqual([1, 4, 3])
+    })
+  })
 })

--- a/src/services/Array/index.ts
+++ b/src/services/Array/index.ts
@@ -9,6 +9,21 @@ export class ArrayService {
 
     return [...array.slice(0, idx).concat(array.slice(idx + 1))]
   }
+
+  /**
+   * Inserts an element into an array at the given index. Returns a new copy of the extended array.
+   */
+  insertAt<T>(array: T[], idx: number, element: T): T[] {
+    return [...array.slice(0, idx), element, ...array.slice(idx)]
+  }
+
+  /**
+   * Replaces an element in an array at the given index. Returns a new copy of the modified array.
+   */
+  replaceAt<T>(array: T[], idx: number, element: T): T[] {
+    array = this.removeAt(array, idx)
+    return this.insertAt(array, idx, element)
+  }
 }
 
 export const array = new ArrayService()

--- a/src/services/Array/index.ts
+++ b/src/services/Array/index.ts
@@ -11,18 +11,10 @@ export class ArrayService {
   }
 
   /**
-   * Inserts an element into an array at the given index. Returns a new copy of the extended array.
-   */
-  insertAt<T>(array: T[], idx: number, element: T): T[] {
-    return [...array.slice(0, idx), element, ...array.slice(idx)]
-  }
-
-  /**
    * Replaces an element in an array at the given index. Returns a new copy of the modified array.
    */
   replaceAt<T>(array: T[], idx: number, element: T): T[] {
-    array = this.removeAt(array, idx)
-    return this.insertAt(array, idx, element)
+    return [...array.slice(0, idx), element, ...array.slice(idx + 1)]
   }
 }
 

--- a/src/ui/components/Field/Field.tsx
+++ b/src/ui/components/Field/Field.tsx
@@ -27,6 +27,27 @@ export const rotationTransform = 'rotate(180deg)'
 export const selectedCardLabel = 'Selected field card'
 export const unselectedCardLabel = 'Unselected field card'
 
+const EmptyPlot = ({
+  cardSize = CardSize.SMALL,
+}: Pick<FieldProps, 'cardSize'>) => {
+  const theme = useTheme()
+  return (
+    <Grid item xs={6} sm={4} md={2}>
+      <Box
+        height={CARD_DIMENSIONS[cardSize].height}
+        width={CARD_DIMENSIONS[cardSize].width}
+        sx={{
+          mx: 'auto',
+          outlineStyle: 'solid',
+          outlineWidth: '2px',
+          outlineColor: theme.palette.divider,
+          borderRadius: theme.shape.borderRadius,
+        }}
+      />
+    </Grid>
+  )
+}
+
 export const Field = ({
   playerId,
   game,
@@ -129,21 +150,7 @@ export const Field = ({
   const emptyCardSlots = new Array(STANDARD_FIELD_SIZE - crops.length)
     .fill(null)
     .map((_, idx) => {
-      return (
-        <Grid key={`${idx}`} item xs={6} sm={4} md={2}>
-          <Box
-            height={CARD_DIMENSIONS[cardSize].height}
-            width={CARD_DIMENSIONS[cardSize].width}
-            sx={{
-              mx: 'auto',
-              outlineStyle: 'solid',
-              outlineWidth: '2px',
-              outlineColor: theme.palette.divider,
-              borderRadius: theme.shape.borderRadius,
-            }}
-          />
-        </Grid>
-      )
+      return <EmptyPlot key={idx} cardSize={cardSize} />
     })
 
   return (
@@ -162,6 +169,10 @@ export const Field = ({
       >
         {!isSessionOwnerPlayer && emptyCardSlots}
         {crops.map((playedCrop, idx) => {
+          if (!playedCrop) {
+            return <EmptyPlot key={idx} cardSize={cardSize} />
+          }
+
           const { instance: cardInstance } = playedCrop
 
           const isSelected = selectedCardIdx === idx


### PR DESCRIPTION
### How this change can be validated

- [ ] Harvest a crop that isn't the rightmost crop in the field and verify that the cards to the right **don't** shift over to fill in the empty space

### Additional information

![Screenshot of sparse fields](https://github.com/user-attachments/assets/7ce4e3a1-b531-4faa-a788-10e7af527219)

