### PR TITLE
feat(a11y): Show tooltip for various card states

### DIFF
--- a/src/ui/components/Card/Card.test.tsx
+++ b/src/ui/components/Card/Card.test.tsx
@@ -244,18 +244,22 @@ describe('Card', () => {
       expect(screen.getByLabelText('Needs water')).toBeInTheDocument()
     })
 
-    test('shows "Needs water" tooltip when canBeWatered is true', () => {
+    test('shows "Ready to be harvested" tooltip when canBeHarvested is true', () => {
       vi.spyOn(useGameStateModule, 'useGameRules').mockReturnValueOnce({
-        gameState: GameState.PLAYER_WATERING_CROP,
+        gameState: GameState.WAITING_FOR_PLAYER_TURN_ACTION,
         game,
         selectedWaterCardInHandIdx: 0,
       })
 
       render(
-        <StubCard isInField canBeWatered playerId={game.sessionOwnerPlayerId} />
+        <StubCard
+          isInField
+          canBeHarvested
+          playerId={game.sessionOwnerPlayerId}
+        />
       )
 
-      expect(screen.getByLabelText('Needs water')).toBeInTheDocument()
+      expect(screen.getByLabelText('Ready to be harvested')).toBeInTheDocument()
     })
 
     test('shows no tooltip when neither canBeWatered nor canBeHarvested is true', () => {

--- a/src/ui/components/Card/Card.test.tsx
+++ b/src/ui/components/Card/Card.test.tsx
@@ -226,4 +226,67 @@ describe('Card', () => {
       cropIdxInFieldToHarvest: cardIdx,
     })
   })
+
+  describe('Tooltip variations', () => {
+    const game = stubGame()
+
+    test('shows "Needs water" tooltip when canBeWatered is true', () => {
+      vi.spyOn(useGameStateModule, 'useGameRules').mockReturnValueOnce({
+        gameState: GameState.PLAYER_WATERING_CROP,
+        game,
+        selectedWaterCardInHandIdx: 0,
+      })
+
+      render(
+        <StubCard isInField canBeWatered playerId={game.sessionOwnerPlayerId} />
+      )
+
+      expect(screen.getByLabelText('Needs water')).toBeInTheDocument()
+    })
+
+    test('shows "Needs water" tooltip when canBeWatered is true', () => {
+      vi.spyOn(useGameStateModule, 'useGameRules').mockReturnValueOnce({
+        gameState: GameState.PLAYER_WATERING_CROP,
+        game,
+        selectedWaterCardInHandIdx: 0,
+      })
+
+      render(
+        <StubCard isInField canBeWatered playerId={game.sessionOwnerPlayerId} />
+      )
+
+      expect(screen.getByLabelText('Needs water')).toBeInTheDocument()
+    })
+
+    test('shows no tooltip when neither canBeWatered nor canBeHarvested is true', () => {
+      vi.spyOn(useGameStateModule, 'useGameRules').mockReturnValueOnce({
+        gameState: GameState.WAITING_FOR_PLAYER_TURN_ACTION,
+        game,
+        selectedWaterCardInHandIdx: 0,
+      })
+
+      render(<StubCard isInField playerId={game.sessionOwnerPlayerId} />)
+
+      expect(screen.queryByTitle('Needs water')).not.toBeInTheDocument()
+      expect(
+        screen.queryByLabelText('Ready to be harvested')
+      ).not.toBeInTheDocument()
+    })
+
+    test('tooltip does not show when isSessionOwnersCard is false', () => {
+      vi.spyOn(useGameStateModule, 'useGameRules').mockReturnValueOnce({
+        gameState: GameState.WAITING_FOR_PLAYER_TURN_ACTION,
+        game,
+        selectedWaterCardInHandIdx: 0,
+      })
+
+      render(
+        <StubCard isInField canBeHarvested playerId="some-other-player-id" />
+      )
+
+      expect(
+        screen.queryByLabelText('Ready to be harvested')
+      ).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/ui/components/Card/CardCore.tsx
+++ b/src/ui/components/Card/CardCore.tsx
@@ -5,6 +5,7 @@ import Paper from '@mui/material/Paper'
 import { darken, lighten } from '@mui/material/styles'
 import useTheme from '@mui/material/styles/useTheme'
 import Typography from '@mui/material/Typography'
+import Tooltip from '@mui/material/Tooltip'
 import { AnimatePresence, motion } from 'motion/react'
 import React, { useContext, useRef } from 'react'
 
@@ -32,11 +33,6 @@ export const cardFlipWrapperClassName = 'CardFlipWrapper'
 const cropWaterIndicatorOutlineColor = '#0072ff'
 const cropHarvestIndicatorSessionOwnerOutlineColor = '#0fc400'
 const cropHarvestIndicatorOpponentOutlineColor = '#ff7510'
-
-// TODO: Improve visual accessibility by showing visual indications for the
-// following idle states that do not rely on differentiation by color:
-//   - Waterable crops
-//   - Harvestable crops
 
 export const CardCore = React.forwardRef<HTMLDivElement, CardProps>(
   function CardCore(
@@ -170,6 +166,27 @@ export const CardCore = React.forwardRef<HTMLDivElement, CardProps>(
 
       default:
     }
+
+    const showWaterableState =
+      isInField &&
+      canBeWatered &&
+      gameState === GameState.PLAYER_WATERING_CROP &&
+      game.currentPlayerId === playerId &&
+      isCropCardInstance(card)
+
+    const showHarvestableState =
+      isInField && canBeHarvested && isCropCardInstance(card)
+
+    let tooltipTitle = ''
+
+    if (isSessionOwnersCard) {
+      if (showWaterableState) {
+        tooltipTitle = 'Needs water'
+      } else if (showHarvestableState) {
+        tooltipTitle = 'Ready to be harvested'
+      }
+    }
+
     return (
       <AnimatePresence>
         <Box
@@ -190,154 +207,150 @@ export const CardCore = React.forwardRef<HTMLDivElement, CardProps>(
             animate={{ scale: 1 }}
             style={{ originX: 0.5, originY: 0.5 }}
           >
-            <Box
-              className={cardFlipWrapperClassName}
-              sx={[
-                {
-                  height: CARD_DIMENSIONS[size].height,
-                  position: 'relative',
-                  transformStyle: 'preserve-3d',
-                  width: CARD_DIMENSIONS[size].width,
-                  ...(isFlipped && {
-                    transform: 'rotateY(180deg)',
-                  }),
-                  transition: theme.transitions.create([
-                    'transform',
-                    'box-shadow',
-                  ]),
-                },
-              ]}
-            >
-              <Paper
-                ref={cardRef}
-                {...paperProps}
-                data-chromatic="ignore"
+            <Tooltip title={tooltipTitle} placement="top" arrow>
+              <Box
+                className={cardFlipWrapperClassName}
                 sx={[
                   {
-                    backfaceVisibility: 'hidden',
-                    background:
-                      theme.palette.mode === 'light'
-                        ? darken(theme.palette.background.paper, 0.05)
-                        : lighten(theme.palette.background.paper, 0.15),
-                    display: 'flex',
-                    flexDirection: 'column',
-                    height: 1,
-                    p: theme.spacing(1),
-                    position: 'absolute',
-                    width: 1,
-                    ...(isInField &&
-                      canBeWatered &&
-                      gameState === GameState.PLAYER_WATERING_CROP &&
-                      game.currentPlayerId === playerId &&
-                      isCropCardInstance(card) && {
+                    height: CARD_DIMENSIONS[size].height,
+                    position: 'relative',
+                    transformStyle: 'preserve-3d',
+                    width: CARD_DIMENSIONS[size].width,
+                    ...(isFlipped && {
+                      transform: 'rotateY(180deg)',
+                    }),
+                    transition: theme.transitions.create([
+                      'transform',
+                      'box-shadow',
+                    ]),
+                  },
+                ]}
+              >
+                <Paper
+                  ref={cardRef}
+                  {...paperProps}
+                  data-chromatic="ignore"
+                  sx={[
+                    {
+                      backfaceVisibility: 'hidden',
+                      background:
+                        theme.palette.mode === 'light'
+                          ? darken(theme.palette.background.paper, 0.05)
+                          : lighten(theme.palette.background.paper, 0.15),
+                      display: 'flex',
+                      flexDirection: 'column',
+                      height: 1,
+                      p: theme.spacing(1),
+                      position: 'absolute',
+                      width: 1,
+                      ...(showWaterableState && {
                         filter: `drop-shadow(0px 0px 24px ${cropWaterIndicatorOutlineColor})`,
                       }),
-                    ...(isInField &&
-                      canBeHarvested &&
-                      isCropCardInstance(card) && {
+                      ...(showHarvestableState && {
                         filter: isSessionOwnersCard
                           ? `drop-shadow(0px 0px 24px ${cropHarvestIndicatorSessionOwnerOutlineColor})`
                           : `drop-shadow(0px 0px 24px ${cropHarvestIndicatorOpponentOutlineColor})`,
                       }),
-                  },
-                ]}
-              >
-                <Typography
-                  variant="overline"
-                  sx={{ fontWeight: theme.typography.fontWeightBold }}
+                    },
+                  ]}
                 >
-                  {card.name}
-                </Typography>
-                <Box
-                  sx={{
-                    height: '50%',
-                    display: 'flex',
-                    background: theme.palette.common.white,
-                    backgroundImage: `url(${ui.dirt})`,
-                    backgroundSize: '100%',
-                    backgroundRepeat: 'repeat',
-                    borderColor: theme.palette.divider,
-                    borderRadius: `${theme.shape.borderRadius}px`,
-                    borderWidth: 1,
-                    borderStyle: 'solid',
-                    imageRendering: 'pixelated',
-                  }}
-                >
-                  <Image
-                    src={imageSrc}
-                    alt={card.name}
+                  <Typography
+                    variant="overline"
+                    sx={{ fontWeight: theme.typography.fontWeightBold }}
+                  >
+                    {card.name}
+                  </Typography>
+                  <Box
                     sx={{
-                      height: `${100 * imageScale}%`,
-                      p: 0,
-                      m: 'auto',
+                      height: '50%',
+                      display: 'flex',
+                      background: theme.palette.common.white,
+                      backgroundImage: `url(${ui.dirt})`,
+                      backgroundSize: '100%',
+                      backgroundRepeat: 'repeat',
+                      borderColor: theme.palette.divider,
+                      borderRadius: `${theme.shape.borderRadius}px`,
+                      borderWidth: 1,
+                      borderStyle: 'solid',
                       imageRendering: 'pixelated',
-                      filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
                     }}
-                  />
-                </Box>
-                <Divider sx={{ my: theme.spacing(1) }} />
-                <Box sx={{ height: '50%' }}>{children}</Box>
-                {showPlayCardButton && (
-                  <Box position="absolute" right="-100%" width={1} px={1}>
-                    <Typography>
-                      <Button
-                        variant="contained"
-                        onClick={() => void handlePlayCard()}
-                      >
-                        {isCropCardInstance(card) && 'Play crop'}
-                        {isWaterCardInstance(card) && 'Water a crop'}
-                      </Button>
-                    </Typography>
+                  >
+                    <Image
+                      src={imageSrc}
+                      alt={card.name}
+                      sx={{
+                        height: `${100 * imageScale}%`,
+                        p: 0,
+                        m: 'auto',
+                        imageRendering: 'pixelated',
+                        filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
+                      }}
+                    />
                   </Box>
-                )}
-                {showWaterCropButton && (
-                  <Box position="absolute" right="-100%" width={1} px={1}>
-                    <Typography>
-                      <Button variant="contained" onClick={handleWaterCrop}>
-                        Water crop
-                      </Button>
-                    </Typography>
-                  </Box>
-                )}
-                {showHarvestCropButton && (
-                  <Box position="absolute" right="-100%" width={1} px={1}>
-                    <Typography>
-                      <Button
-                        variant="contained"
-                        color="success"
-                        onClick={handleHarvestCrop}
-                      >
-                        Harvest crop
-                      </Button>
-                    </Typography>
-                  </Box>
-                )}
-              </Paper>
-              <Paper
-                {...paperProps}
-                sx={{
-                  alignItems: 'center',
-                  backfaceVisibility: 'hidden',
-                  display: 'flex',
-                  height: 1,
-                  position: 'absolute',
-                  textAlign: 'center',
-                  transform: 'rotateY(180deg)',
-                  width: 1,
-                }}
-              >
-                <Typography
-                  variant="h2"
+                  <Divider sx={{ my: theme.spacing(1) }} />
+                  <Box sx={{ height: '50%' }}>{children}</Box>
+                  {showPlayCardButton && (
+                    <Box position="absolute" right="-100%" width={1} px={1}>
+                      <Typography>
+                        <Button
+                          variant="contained"
+                          onClick={() => void handlePlayCard()}
+                        >
+                          {isCropCardInstance(card) && 'Play crop'}
+                          {isWaterCardInstance(card) && 'Water a crop'}
+                        </Button>
+                      </Typography>
+                    </Box>
+                  )}
+                  {showWaterCropButton && (
+                    <Box position="absolute" right="-100%" width={1} px={1}>
+                      <Typography>
+                        <Button variant="contained" onClick={handleWaterCrop}>
+                          Water crop
+                        </Button>
+                      </Typography>
+                    </Box>
+                  )}
+                  {showHarvestCropButton && (
+                    <Box position="absolute" right="-100%" width={1} px={1}>
+                      <Typography>
+                        <Button
+                          variant="contained"
+                          color="success"
+                          onClick={handleHarvestCrop}
+                        >
+                          Harvest crop
+                        </Button>
+                      </Typography>
+                    </Box>
+                  )}
+                </Paper>
+                <Paper
+                  {...paperProps}
                   sx={{
-                    ...(size === CardSize.SMALL && theme.typography.h6),
-                    ...(size === CardSize.MEDIUM && theme.typography.h5),
-                    ...(size === CardSize.LARGE && theme.typography.h4),
+                    alignItems: 'center',
+                    backfaceVisibility: 'hidden',
+                    display: 'flex',
+                    height: 1,
+                    position: 'absolute',
+                    textAlign: 'center',
+                    transform: 'rotateY(180deg)',
+                    width: 1,
                   }}
                 >
-                  Farmhand Shuffle
-                </Typography>
-              </Paper>
-            </Box>
+                  <Typography
+                    variant="h2"
+                    sx={{
+                      ...(size === CardSize.SMALL && theme.typography.h6),
+                      ...(size === CardSize.MEDIUM && theme.typography.h5),
+                      ...(size === CardSize.LARGE && theme.typography.h4),
+                    }}
+                  >
+                    Farmhand Shuffle
+                  </Typography>
+                </Paper>
+              </Box>
+            </Tooltip>
           </motion.div>
         </Box>
       </AnimatePresence>


### PR DESCRIPTION
### How this change can be validated

- [ ] Verify that an appropriate tooltip is shown whenever the player has a card that's ready to be watered
- [ ] Verify that an appropriate tooltip is shown whenever the player has a card that's ready for harvesting

### Additional information

[Screencast of card tooltips](https://github.com/user-attachments/assets/2d592519-3d06-4c9a-bb64-50b78592afc4)
