### PR TITLE
feat(game): Implement crop price fluctuations

### DIFF
--- a/src/game/reducers/start-turn/index.test.ts
+++ b/src/game/reducers/start-turn/index.test.ts
@@ -127,4 +127,11 @@ describe('startTurn', () => {
       { instance: carrot2, wasWateredTuringTurn: false, waterCards: 1 },
     ])
   })
+
+  test('updates prices', () => {
+    const newGame = startTurn(game, player1Id)
+
+    expect(newGame.buffedCrop).not.toBeNull()
+    expect(newGame.nerfedCrop).not.toBeNull()
+  })
 })

--- a/src/game/reducers/start-turn/index.ts
+++ b/src/game/reducers/start-turn/index.ts
@@ -4,6 +4,7 @@ import { IGame, IPlayer } from '../../types'
 import { drawCard } from '../draw-card'
 import { payFromPlayerToCommunity } from '../pay-from-player-to-community'
 import { updatePlayedCrop } from '../update-played-crop'
+import { updatePrices } from '../update-prices'
 
 export const startTurn = (game: IGame, playerId: IPlayer['id']): IGame => {
   game = payFromPlayerToCommunity(game, STANDARD_TAX_AMOUNT, playerId)
@@ -23,6 +24,8 @@ export const startTurn = (game: IGame, playerId: IPlayer['id']): IGame => {
 
     game = updatePlayedCrop(game, playerId, i, { wasWateredTuringTurn: false })
   }
+
+  game = updatePrices(game)
 
   return game
 }

--- a/src/game/reducers/update-prices/index.test.ts
+++ b/src/game/reducers/update-prices/index.test.ts
@@ -1,0 +1,15 @@
+import { stubGame } from '../../../test-utils/stubs/game'
+import { isCropPriceFluctuation } from '../../types/guards'
+
+import { updatePrices } from './'
+
+describe('updatePrices', () => {
+  it('should set buffedCrop and nerfedCrop with different crops', () => {
+    const mockGame = stubGame()
+    const updatedGame = updatePrices(mockGame)
+
+    expect(isCropPriceFluctuation(updatedGame.buffedCrop)).toEqual(true)
+    expect(isCropPriceFluctuation(updatedGame.nerfedCrop)).toEqual(true)
+    expect(updatedGame.buffedCrop?.crop).not.toBe(updatedGame.nerfedCrop?.crop)
+  })
+})

--- a/src/game/reducers/update-prices/index.ts
+++ b/src/game/reducers/update-prices/index.ts
@@ -1,0 +1,24 @@
+import shuffle from 'lodash.shuffle'
+
+import * as crops from '../../cards/crops'
+import { IGame } from '../../types'
+import { updateGame } from '../update-game'
+
+export const updatePrices = (game: IGame) => {
+  // TODO: Only buff/nerf crops that are present in either player's decks
+  const [cropToBuff, cropToNerf] = shuffle(Object.values(crops))
+
+  // TODO: Make the buff/nerf multipliers variable
+  game = updateGame(game, {
+    buffedCrop: {
+      crop: cropToBuff,
+      multiplier: 2,
+    },
+    nerfedCrop: {
+      crop: cropToNerf,
+      multiplier: 0.5,
+    },
+  })
+
+  return game
+}

--- a/src/game/services/Factory/index.ts
+++ b/src/game/services/Factory/index.ts
@@ -57,6 +57,8 @@ export class FactoryService {
       sessionOwnerPlayerId,
       table,
       currentPlayerId,
+      buffedCrop: null,
+      nerfedCrop: null,
       ...overrides,
     }
 

--- a/src/game/services/Pricing/index.test.ts
+++ b/src/game/services/Pricing/index.test.ts
@@ -1,6 +1,7 @@
 import { stubGame } from '../../../test-utils/stubs/game'
 import { carrot } from '../../cards'
 import { updateTable } from '../../reducers/update-table'
+import { updateGame } from '../../reducers/update-game'
 
 import { pricing } from '.'
 
@@ -24,6 +25,40 @@ describe('PricingService', () => {
       game = updateTable(game, { communityFund: 10 })
 
       expect(pricing.getCropSaleValue(game, carrot)).toBe(6)
+    })
+
+    it('should increase the sale value when the crop is buffed', () => {
+      let game = stubGame()
+
+      game = updateTable(game, {
+        communityFund: 100,
+      })
+
+      game = updateGame(game, {
+        // NOTE: Crop is spread here to prevent false-positives by creating a
+        // new object that would break any improper object reference
+        // comparisons.
+        buffedCrop: { crop: { ...carrot }, multiplier: 2 },
+      })
+
+      expect(pricing.getCropSaleValue(game, carrot)).toBe(12)
+    })
+
+    it('should decrease the sale value when the crop is nerfed', () => {
+      let game = stubGame()
+
+      game = updateTable(game, {
+        communityFund: 100,
+      })
+
+      game = updateGame(game, {
+        // NOTE: Crop is spread here to prevent false-positives by creating a
+        // new object that would break any improper object reference
+        // comparisons.
+        nerfedCrop: { crop: { ...carrot }, multiplier: 0.5 },
+      })
+
+      expect(pricing.getCropSaleValue(game, carrot)).toBe(3)
     })
   })
 })

--- a/src/game/services/Pricing/index.ts
+++ b/src/game/services/Pricing/index.ts
@@ -23,12 +23,26 @@ export class PricingService {
    * @returns The sale value of the crop.
    */
   getCropSaleValue = (game: IGame, crop: ICrop) => {
-    const cropValue = Math.min(
-      this.getCropBaseValue(crop),
+    const cropBaseValue = this.getCropBaseValue(crop)
+
+    let cropAdjustedValue = cropBaseValue
+
+    if (crop.id === game.buffedCrop?.crop.id) {
+      cropAdjustedValue *= game.buffedCrop.multiplier
+    }
+
+    if (crop.id === game.nerfedCrop?.crop.id) {
+      cropAdjustedValue *= game.nerfedCrop.multiplier
+    }
+
+    cropAdjustedValue = Math.floor(cropAdjustedValue)
+
+    const cropValueReducedByAvailableCommunityFunds = Math.min(
+      cropAdjustedValue,
       game.table.communityFund
     )
 
-    return cropValue
+    return cropValueReducedByAvailableCommunityFunds
   }
 }
 

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -4,6 +4,7 @@ import {
   GameState,
   ICard,
   ICrop,
+  ICropPriceFluctuation,
   IField,
   IGame,
   IPlayedCrop,
@@ -101,6 +102,20 @@ export const isTable = (obj: unknown): obj is ITable => {
   )
 }
 
+export const isCropPriceFluctuation = (
+  obj: unknown
+): obj is ICropPriceFluctuation => {
+  if (typeof obj !== 'object') return false
+  if (obj === null) return true
+
+  return (
+    'crop' in obj &&
+    isCrop(obj.crop) &&
+    'multiplier' in obj &&
+    typeof obj.multiplier === 'number'
+  )
+}
+
 export const isGame = (obj: unknown): obj is IGame => {
   if (typeof obj !== 'object' || obj === null) return false
 
@@ -110,7 +125,11 @@ export const isGame = (obj: unknown): obj is IGame => {
     'currentPlayerId' in obj &&
     (typeof obj.currentPlayerId === 'string' || obj.currentPlayerId === null) &&
     'sessionOwnerPlayerId' in obj &&
-    typeof obj.sessionOwnerPlayerId === 'string'
+    typeof obj.sessionOwnerPlayerId === 'string' &&
+    'buffedCrop' in obj &&
+    isCropPriceFluctuation(obj.buffedCrop) &&
+    'nerfedCrop' in obj &&
+    isCropPriceFluctuation(obj.nerfedCrop)
   )
 }
 

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -105,8 +105,7 @@ export const isTable = (obj: unknown): obj is ITable => {
 export const isCropPriceFluctuation = (
   obj: unknown
 ): obj is ICropPriceFluctuation => {
-  if (typeof obj !== 'object') return false
-  if (obj === null) return true
+  if (typeof obj !== 'object' || obj === null) return false
 
   return (
     'crop' in obj &&
@@ -127,9 +126,9 @@ export const isGame = (obj: unknown): obj is IGame => {
     'sessionOwnerPlayerId' in obj &&
     typeof obj.sessionOwnerPlayerId === 'string' &&
     'buffedCrop' in obj &&
-    isCropPriceFluctuation(obj.buffedCrop) &&
+    (obj.buffedCrop === null || isCropPriceFluctuation(obj.buffedCrop)) &&
     'nerfedCrop' in obj &&
-    isCropPriceFluctuation(obj.nerfedCrop)
+    (obj.nerfedCrop === null || isCropPriceFluctuation(obj.nerfedCrop))
   )
 }
 

--- a/src/game/types/index.ts
+++ b/src/game/types/index.ts
@@ -153,6 +153,11 @@ export interface IPlayer {
  */
 export type IPlayerSeed = Pick<IPlayer, 'id' | 'deck'>
 
+export interface ICropPriceFluctuation {
+  readonly crop: ICrop
+  readonly multiplier: number
+}
+
 export interface ITable {
   /**
    * Each players' card area at the table.
@@ -177,6 +182,16 @@ export interface IGame {
    * The IPlayer['id'] of the player whose turn it is.
    */
   readonly currentPlayerId: IPlayer['id'] | null
+
+  /**
+   * The crop that is currently selling for higher than normal.
+   */
+  readonly buffedCrop: ICropPriceFluctuation | null
+
+  /**
+   * The crop that is currently selling for lower than normal.
+   */
+  readonly nerfedCrop: ICropPriceFluctuation | null
 }
 
 export enum GameEvent {

--- a/src/ui/components/Card/CardCore.tsx
+++ b/src/ui/components/Card/CardCore.tsx
@@ -4,8 +4,8 @@ import Divider from '@mui/material/Divider'
 import Paper from '@mui/material/Paper'
 import { darken, lighten } from '@mui/material/styles'
 import useTheme from '@mui/material/styles/useTheme'
-import Typography from '@mui/material/Typography'
 import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
 import { AnimatePresence, motion } from 'motion/react'
 import React, { useContext, useRef } from 'react'
 
@@ -18,12 +18,12 @@ import {
 } from '../../../game/types'
 import { CARD_DIMENSIONS } from '../../config/dimensions'
 import { useGameRules } from '../../hooks/useGameRules'
-import { cards, isCardImageKey, ui } from '../../img'
+import { ui } from '../../img'
 import { isSxArray } from '../../type-guards'
 import { CardSize } from '../../types'
 import { ActorContext } from '../Game/ActorContext'
 import { ShellContext } from '../Game/ShellContext'
-import { Image } from '../Image'
+import { getCardImageSrc, Image } from '../Image'
 
 import { CardProps } from './types'
 
@@ -62,12 +62,6 @@ export const CardCore = React.forwardRef<HTMLDivElement, CardProps>(
     const theme = useTheme()
     const cardRef = useRef<HTMLDivElement>(null)
     const { setIsHandInViewport } = useContext(ShellContext)
-
-    const imageSrc = isCardImageKey(card.id) ? cards[card.id] : ui.pixel
-
-    if (imageSrc === ui.pixel) {
-      console.error(`Card ID ${card.id} does not have an image configured`)
-    }
 
     const handlePlayCard = async () => {
       if (onBeforePlay) {
@@ -276,7 +270,7 @@ export const CardCore = React.forwardRef<HTMLDivElement, CardProps>(
                     }}
                   >
                     <Image
-                      src={imageSrc}
+                      src={getCardImageSrc(card)}
                       alt={card.name}
                       sx={{
                         height: `${100 * imageScale}%`,

--- a/src/ui/components/Image/Image.tsx
+++ b/src/ui/components/Image/Image.tsx
@@ -1,3 +1,21 @@
 import { styled } from '@mui/material/styles'
 
+import { ICard } from '../../../game/types'
+import { isCardImageKey, cards, ui } from '../../img'
+
 export const Image = styled('img')({})
+
+/**
+ * Retrieves the image source for a given card.
+ * @param card - The card object.
+ * @returns The image source URL for the card.
+ */
+export const getCardImageSrc = (card: ICard) => {
+  const isValid = isCardImageKey(card.id)
+
+  if (!isValid) {
+    console.error(`Card ID ${card.id} does not have an image configured`)
+  }
+
+  return isValid ? cards[card.id] : ui.pixel
+}

--- a/src/ui/components/TurnControl/TurnControl.tsx
+++ b/src/ui/components/TurnControl/TurnControl.tsx
@@ -1,9 +1,12 @@
 import AccountBalance from '@mui/icons-material/AccountBalance'
 import AttachMoney from '@mui/icons-material/AttachMoney'
+import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp'
+import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown'
 import Accordion from '@mui/material/Accordion'
 import AccordionActions from '@mui/material/AccordionActions'
 import AccordionSummary from '@mui/material/AccordionSummary'
 import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
 import Stack from '@mui/material/Stack'
 import useTheme from '@mui/material/styles/useTheme'
 import Tooltip from '@mui/material/Tooltip'
@@ -18,6 +21,8 @@ import { useGameRules } from '../../hooks/useGameRules'
 import { ActorContext } from '../Game/ActorContext'
 import { ShellContext } from '../Game/ShellContext'
 import { STANDARD_TAX_AMOUNT } from '../../../game/config'
+import { Image } from '../Image'
+import { getCardImageSrc } from '../Image/Image'
 
 export interface TurnControlProps {
   game: IGame
@@ -148,6 +153,34 @@ export const TurnControl = ({ game }: TurnControlProps) => {
             <Typography>{formatNumber(sessionOwnerPlayerFunds)}</Typography>
           </Stack>
         </Tooltip>
+        {game.buffedCrop && (
+          <Tooltip
+            title={`Sell ${game.buffedCrop.crop.name} cards now for ${game.buffedCrop.multiplier}x value`}
+            arrow
+          >
+            <Stack direction="row" alignItems="center">
+              <Chip
+                color="success"
+                icon={<KeyboardArrowUp />}
+                label={
+                  <Image
+                    src={getCardImageSrc(game.buffedCrop.crop)}
+                    sx={{
+                      imageRendering: 'pixelated',
+                      filter: `drop-shadow(0 0 5px ${theme.palette.common.white})`,
+                    }}
+                  />
+                }
+                sx={{
+                  backgroundColor: theme.palette.success.light,
+                  outlineColor: theme.palette.success.main,
+                  outlineWidth: 1,
+                  outlineStyle: 'solid',
+                }}
+              />
+            </Stack>
+          </Tooltip>
+        )}
         <Tooltip title="Community funds" arrow>
           <Stack
             direction="row"
@@ -164,6 +197,42 @@ export const TurnControl = ({ game }: TurnControlProps) => {
             <Typography>{formatNumber(game.table.communityFund)}</Typography>
           </Stack>
         </Tooltip>
+        {game.nerfedCrop && (
+          <Tooltip
+            title={`${game.nerfedCrop.crop.name} cards now sell for ${game.nerfedCrop.multiplier}x value`}
+            arrow
+          >
+            <Stack direction="row" alignItems="center">
+              <Chip
+                sx={{
+                  flexDirection: 'row-reverse',
+                  '& .MuiSvgIcon-root': {
+                    ml: -0.75,
+                    mr: 0.75,
+                  },
+                  '& .MuiChip-label': {
+                    pr: 1,
+                  },
+                  backgroundColor: theme.palette.error.light,
+                  outlineColor: theme.palette.error.dark,
+                  outlineWidth: 1,
+                  outlineStyle: 'solid',
+                }}
+                color="error"
+                icon={<KeyboardArrowDown />}
+                label={
+                  <Image
+                    src={getCardImageSrc(game.nerfedCrop.crop)}
+                    sx={{
+                      imageRendering: 'pixelated',
+                      filter: `drop-shadow(0 0 5px ${theme.palette.common.black})`,
+                    }}
+                  />
+                }
+              />
+            </Stack>
+          </Tooltip>
+        )}
         <Tooltip
           title={`${funAnimalName(currentPlayerId ?? '')}'s funds`}
           arrow


### PR DESCRIPTION
### How this change can be validated

- [ ] Verify that value multipliers indicated at the top of the screen during a turn are applied as indicated when harvesting a crop card

### Additional information

The UX for this feature is a little bare bones at the moment, but it seems to be working well. I'm planning to improve it in a future iteration.

[Screencast of crop price fluctuations](https://github.com/user-attachments/assets/dd88068a-284c-4db7-8e27-e283963de5e4)
