### PR TITLE
Rename `getCardFromHand` to `getCardInstanceFromHand`

### DIFF
--- a/src/game/reducers/move-card-from-hand-to-field/index.ts
+++ b/src/game/reducers/move-card-from-hand-to-field/index.ts
@@ -23,18 +23,13 @@ export const moveCardFromHandToField = (
 ) => {
   const player = lookup.getPlayer(match, playerId)
   const { hand } = player
-  const cardId = hand[cardIdxInHand]
+  const cardInstance = hand[cardIdxInHand]
 
-  if (!cardId) {
+  if (!cardInstance) {
     throw new InvalidCardIndexError(cardIdxInHand, playerId)
   }
 
   const newHand = array.removeAt(hand, cardIdxInHand)
-  const cardInstance = lookup.getCardInstanceFromHand(
-    match,
-    playerId,
-    cardIdxInHand
-  )
 
   let playedCard: IPlayedCrop | IPlayedTool
 

--- a/src/game/reducers/move-card-from-hand-to-field/index.ts
+++ b/src/game/reducers/move-card-from-hand-to-field/index.ts
@@ -30,7 +30,11 @@ export const moveCardFromHandToField = (
   }
 
   const newHand = array.removeAt(hand, cardIdxInHand)
-  const cardInstance = lookup.getCardFromHand(match, playerId, cardIdxInHand)
+  const cardInstance = lookup.getCardInstanceFromHand(
+    match,
+    playerId,
+    cardIdxInHand
+  )
 
   let playedCard: IPlayedCrop | IPlayedTool
 

--- a/src/game/services/Lookup/index.test.ts
+++ b/src/game/services/Lookup/index.test.ts
@@ -19,7 +19,7 @@ import { lookup } from '.'
 const match = stubMatch()
 
 describe('Lookup', () => {
-  describe('getCardFromHand', () => {
+  describe('getCardInstanceFromHand', () => {
     let mutatedMatch: IMatch
     const { id: player1Id } = stubPlayer1
 
@@ -36,7 +36,11 @@ describe('Lookup', () => {
     })
 
     test('returns card from hand', () => {
-      const cardInstance = lookup.getCardFromHand(mutatedMatch, player1Id, 0)
+      const cardInstance = lookup.getCardInstanceFromHand(
+        mutatedMatch,
+        player1Id,
+        0
+      )
 
       expect(cardInstance).toBe(stubCarrot)
     })
@@ -49,7 +53,11 @@ describe('Lookup', () => {
       }
 
       expect(() => {
-        lookup.getCardFromHand(mutatedMatch, player1Id, player.hand.length)
+        lookup.getCardInstanceFromHand(
+          mutatedMatch,
+          player1Id,
+          player.hand.length
+        )
       }).toThrow()
     })
   })

--- a/src/game/services/Lookup/index.ts
+++ b/src/game/services/Lookup/index.ts
@@ -18,8 +18,7 @@ import {
 } from '../Rules/errors'
 
 export class LookupService {
-  // TODO: Rename to getCardInstanceFromHand
-  getCardFromHand = (
+  getCardInstanceFromHand = (
     match: IMatch,
     playerId: IPlayer['id'],
     cardIdx: number
@@ -41,7 +40,7 @@ export class LookupService {
    * @throws InvalidCardError if card is not a CropInstance.
    */
   getCropFromHand(match: IMatch, playerId: IPlayer['id'], cardIdx: number) {
-    const cropInstance = this.getCardFromHand(match, playerId, cardIdx)
+    const cropInstance = this.getCardInstanceFromHand(match, playerId, cardIdx)
 
     if (!isCrop(cropInstance)) {
       throw new InvalidCardError(`${cropInstance.id} is not a crop card.`)

--- a/src/game/services/Rules/state-machine/plantingCardState.ts
+++ b/src/game/services/Rules/state-machine/plantingCardState.ts
@@ -47,7 +47,7 @@ export const plantingCardState: RulesMachineConfig['states'] = {
         const { playerId, cardIdxInHand, fieldIdxToPlace } = event
 
         try {
-          const cardInstance = lookup.getCardFromHand(
+          const cardInstance = lookup.getCardInstanceFromHand(
             match,
             playerId,
             cardIdxInHand

--- a/src/game/services/Rules/state-machine/playingEventCard.ts
+++ b/src/game/services/Rules/state-machine/playingEventCard.ts
@@ -34,23 +34,23 @@ export const playingEventCard: RulesMachineConfig['states'] = {
 
         const { currentPlayerId, sessionOwnerPlayerId } = match
         const { playerId, cardIdxInHand } = event
-        const card = lookup.getCardInstanceFromHand(
+        const cardInstance = lookup.getCardInstanceFromHand(
           match,
           playerId,
           cardIdxInHand
         )
 
-        assertIsEventCardInstance(card)
+        assertIsEventCardInstance(cardInstance)
         assertCurrentPlayer(currentPlayerId)
 
         triggerNotification({
           type: ShellNotificationType.EVENT_CARD_PLAYED,
           payload: {
-            eventCard: card,
+            eventCard: cardInstance,
           },
         })
 
-        match = card.applyEffect(context).match
+        match = cardInstance.applyEffect(context).match
         match = moveFromHandToDiscardPile(match, currentPlayerId, cardIdxInHand)
 
         if (currentPlayerId === sessionOwnerPlayerId) {

--- a/src/game/services/Rules/state-machine/playingEventCard.ts
+++ b/src/game/services/Rules/state-machine/playingEventCard.ts
@@ -34,7 +34,11 @@ export const playingEventCard: RulesMachineConfig['states'] = {
 
         const { currentPlayerId, sessionOwnerPlayerId } = match
         const { playerId, cardIdxInHand } = event
-        const card = lookup.getCardFromHand(match, playerId, cardIdxInHand)
+        const card = lookup.getCardInstanceFromHand(
+          match,
+          playerId,
+          cardIdxInHand
+        )
 
         assertIsEventCardInstance(card)
         assertCurrentPlayer(currentPlayerId)

--- a/src/game/services/Rules/state-machine/playingToolCard.ts
+++ b/src/game/services/Rules/state-machine/playingToolCard.ts
@@ -37,27 +37,30 @@ export const playingToolCard: RulesMachineConfig['states'] = {
 
         const { currentPlayerId, sessionOwnerPlayerId } = match
         const { playerId, cardIdxInHand } = event
-        const card = lookup.getCardInstanceFromHand(
+        const cardInstance = lookup.getCardInstanceFromHand(
           match,
           playerId,
           cardIdxInHand
         )
 
-        assertIsToolCardInstance(card)
+        assertIsToolCardInstance(cardInstance)
         assertCurrentPlayer(currentPlayerId)
 
-        if (!card.isPlantable || currentPlayerId !== sessionOwnerPlayerId) {
+        if (
+          !cardInstance.isPlantable ||
+          currentPlayerId !== sessionOwnerPlayerId
+        ) {
           triggerNotification({
             type: ShellNotificationType.TOOL_CARD_PLAYED,
             payload: {
-              toolCard: card,
+              toolCard: cardInstance,
             },
           })
         }
 
-        match = card.applyEffect?.(context).match ?? match
+        match = cardInstance.applyEffect?.(context).match ?? match
 
-        if (card.isPlantable) {
+        if (cardInstance.isPlantable) {
           enqueue.raise({
             type: MatchEvent.PLAY_PLANTABLE_TOOL,
             cardIdxInHand,

--- a/src/game/services/Rules/state-machine/playingToolCard.ts
+++ b/src/game/services/Rules/state-machine/playingToolCard.ts
@@ -37,7 +37,11 @@ export const playingToolCard: RulesMachineConfig['states'] = {
 
         const { currentPlayerId, sessionOwnerPlayerId } = match
         const { playerId, cardIdxInHand } = event
-        const card = lookup.getCardFromHand(match, playerId, cardIdxInHand)
+        const card = lookup.getCardInstanceFromHand(
+          match,
+          playerId,
+          cardIdxInHand
+        )
 
         assertIsToolCardInstance(card)
         assertCurrentPlayer(currentPlayerId)


### PR DESCRIPTION
Renames the `getCardFromHand` method in `LookupService` to `getCardInstanceFromHand` as per the TODO comment, and updates all related usages and tests.

---
*PR created automatically by Jules for task [7924234304956838529](https://jules.google.com/task/7924234304956838529) started by @jeremyckahn*