### PR TITLE
refactor(useCardInteractions): decompose overloaded cardIdx prop

### DIFF
--- a/src/ui/components/Card/Card.stories.tsx
+++ b/src/ui/components/Card/Card.stories.tsx
@@ -35,7 +35,6 @@ type Story = StoryObj<typeof meta>
 export const CropCard: Story = {
   args: {
     cardInstance: stubCarrot,
-    cardIdx: 0,
     playerId: '',
     isFlipped: false,
   },
@@ -44,11 +43,11 @@ export const CropCard: Story = {
 export const PlayableCropCard: Story = {
   args: {
     cardInstance: stubPumpkin,
-    cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
     size: CardSize.MEDIUM,
     isFocused: true,
+    cardIdxInHand: 0,
   },
   decorators: [
     Story => {
@@ -67,11 +66,11 @@ export const PlayableCropCard: Story = {
 export const PlayableWaterCard: Story = {
   args: {
     cardInstance: stubWater,
-    cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
     size: CardSize.MEDIUM,
     isFocused: true,
+    cardIdxInHand: 0,
   },
   decorators: [
     Story => {
@@ -90,11 +89,11 @@ export const PlayableWaterCard: Story = {
 export const PlayableEventCard: Story = {
   args: {
     cardInstance: stubRain,
-    cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
     size: CardSize.MEDIUM,
     isFocused: true,
+    cardIdxInHand: 0,
   },
   decorators: [
     Story => {
@@ -113,11 +112,11 @@ export const PlayableEventCard: Story = {
 export const PlayableToolCard: Story = {
   args: {
     cardInstance: stubShovel,
-    cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
     size: CardSize.MEDIUM,
     isFocused: true,
+    cardIdxInHand: 0,
   },
   decorators: [
     Story => {
@@ -136,13 +135,13 @@ export const PlayableToolCard: Story = {
 export const WaterableCropCard: Story = {
   args: {
     cardInstance: stubPumpkin,
-    cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
     isInField: true,
     size: CardSize.MEDIUM,
     isFocused: true,
     canBeWatered: true,
+    cropIdxInFieldToWater: 0,
   },
   decorators: [
     Story => {
@@ -161,13 +160,13 @@ export const WaterableCropCard: Story = {
 export const HarvestableSessionOwnerCropCard: Story = {
   args: {
     cardInstance: stubPumpkin,
-    cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
     isInField: true,
     size: CardSize.MEDIUM,
     isFocused: true,
     canBeHarvested: true,
+    cropIdxInFieldToHarvest: 0,
   },
   decorators: [
     Story => {
@@ -186,13 +185,13 @@ export const HarvestableSessionOwnerCropCard: Story = {
 export const HarvestableBuffedSessionOwnerCropCard: Story = {
   args: {
     cardInstance: stubPumpkin,
-    cardIdx: 0,
     playerId: stubPlayer1.id,
     isFlipped: false,
     isInField: true,
     size: CardSize.MEDIUM,
     isFocused: true,
     canBeHarvested: true,
+    cropIdxInFieldToHarvest: 0,
   },
   decorators: [
     Story => {
@@ -217,7 +216,6 @@ export const HarvestableBuffedSessionOwnerCropCard: Story = {
 export const HarvestableOpponentCropCard: Story = {
   args: {
     cardInstance: stubPumpkin,
-    cardIdx: 0,
     playerId: stubPlayer2.id,
     isFlipped: false,
     isInField: true,
@@ -242,7 +240,6 @@ export const HarvestableOpponentCropCard: Story = {
 export const WaterCard: Story = {
   args: {
     cardInstance: stubWater,
-    cardIdx: 0,
     playerId: '',
     isFlipped: false,
   },
@@ -251,7 +248,6 @@ export const WaterCard: Story = {
 export const SmallRainCard: Story = {
   args: {
     cardInstance: stubRain,
-    cardIdx: 0,
     playerId: '',
     size: CardSize.SMALL,
     isFlipped: false,
@@ -261,7 +257,6 @@ export const SmallRainCard: Story = {
 export const RainCard: Story = {
   args: {
     cardInstance: stubRain,
-    cardIdx: 0,
     playerId: '',
     isFlipped: false,
   },
@@ -270,7 +265,6 @@ export const RainCard: Story = {
 export const SmallShovelCard: Story = {
   args: {
     cardInstance: stubShovel,
-    cardIdx: 0,
     playerId: '',
     size: CardSize.SMALL,
     isFlipped: false,
@@ -280,7 +274,6 @@ export const SmallShovelCard: Story = {
 export const ShovelCard: Story = {
   args: {
     cardInstance: stubShovel,
-    cardIdx: 0,
     playerId: '',
     isFlipped: false,
   },
@@ -289,7 +282,6 @@ export const ShovelCard: Story = {
 export const SmallCard: Story = {
   args: {
     cardInstance: stubPumpkin,
-    cardIdx: 0,
     playerId: '',
     size: CardSize.SMALL,
     isFlipped: false,
@@ -299,7 +291,6 @@ export const SmallCard: Story = {
 export const MediumCard: Story = {
   args: {
     cardInstance: stubPumpkin,
-    cardIdx: 0,
     playerId: '',
     isFlipped: false,
     size: CardSize.MEDIUM,
@@ -309,7 +300,6 @@ export const MediumCard: Story = {
 export const LargeCard: Story = {
   args: {
     cardInstance: stubPumpkin,
-    cardIdx: 0,
     playerId: '',
     isFlipped: false,
     size: CardSize.LARGE,

--- a/src/ui/components/Card/Card.test.tsx
+++ b/src/ui/components/Card/Card.test.tsx
@@ -33,12 +33,7 @@ const stubCardInstance = stubCarrot
 const StubCard = ({ ref, ...overrides }: Partial<CardProps> = {}) => (
   <StubShellContext>
     <ActorContext.Provider>
-      <Card
-        cardInstance={stubCardInstance}
-        cardIdx={0}
-        playerId=""
-        {...overrides}
-      />
+      <Card cardInstance={stubCardInstance} playerId="" {...overrides} />
     </ActorContext.Provider>
   </StubShellContext>
 )
@@ -174,6 +169,7 @@ describe('Card', () => {
         <StubCard
           cardInstance={stubCarrot}
           playerId={stubPlayer1.id}
+          cardIdxInHand={0}
           isFocused
         />
       )
@@ -208,6 +204,7 @@ describe('Card', () => {
         <StubCard
           cardInstance={stubWater}
           playerId={stubPlayer1.id}
+          cardIdxInHand={0}
           isFocused
         />
       )
@@ -239,6 +236,7 @@ describe('Card', () => {
       <StubCard
         cardInstance={stubCarrot}
         playerId={stubPlayer1.id}
+        cropIdxInFieldToWater={0}
         isFocused
         isInField
         canBeWatered
@@ -267,12 +265,12 @@ describe('Card', () => {
       match: stubMatch({ selectedWaterCardInHandIdx: 0 }),
     })
 
-    const cardIdx = 2
+    const cropIdxInFieldToHarvest = 2
 
     render(
       <StubCard
         canBeHarvested
-        cardIdx={cardIdx}
+        cropIdxInFieldToHarvest={cropIdxInFieldToHarvest}
         cardInstance={stubCarrot}
         isFocused
         isInField
@@ -289,7 +287,7 @@ describe('Card', () => {
     >({
       type: MatchEvent.HARVEST_CROP,
       playerId: stubPlayer1.id,
-      cropIdxInFieldToHarvest: cardIdx,
+      cropIdxInFieldToHarvest,
     })
   })
 
@@ -305,7 +303,12 @@ describe('Card', () => {
     })
 
     render(
-      <StubCard cardInstance={stubRain} playerId={stubPlayer1.id} isFocused />
+      <StubCard
+        cardInstance={stubRain}
+        playerId={stubPlayer1.id}
+        cardIdxInHand={0}
+        isFocused
+      />
     )
 
     const playCardButton = screen.getByText('Play event')
@@ -332,7 +335,12 @@ describe('Card', () => {
     })
 
     render(
-      <StubCard cardInstance={stubShovel} playerId={stubPlayer1.id} isFocused />
+      <StubCard
+        cardInstance={stubShovel}
+        playerId={stubPlayer1.id}
+        cardIdxInHand={0}
+        isFocused
+      />
     )
 
     const playCardButton = screen.getByText('Play tool')
@@ -362,6 +370,7 @@ describe('Card', () => {
       <StubCard
         cardInstance={stubSprinkler}
         playerId={stubPlayer1.id}
+        cardIdxInField={0}
         isFocused
         isInField
       />
@@ -505,8 +514,8 @@ describe('Card', () => {
           <ActorContext.Provider>
             <Card
               cardInstance={stubShovel}
-              cardIdx={0}
               playerId={stubPlayer1.id}
+              cardIdxInHand={0}
               isFocused
             />
           </ActorContext.Provider>
@@ -542,8 +551,8 @@ describe('Card', () => {
           <ActorContext.Provider>
             <Card
               cardInstance={stubSprinkler}
-              cardIdx={0}
               playerId={stubPlayer1.id}
+              cardIdxInHand={0}
               isFocused
             />
           </ActorContext.Provider>

--- a/src/ui/components/Card/CardCore.tsx
+++ b/src/ui/components/Card/CardCore.tsx
@@ -56,7 +56,10 @@ export const CardCore = React.forwardRef<HTMLDivElement, CardViewProps>(
   function CardCore(
     {
       cardInstance: card,
-      cardIdx,
+      cardIdxInHand,
+      cardIdxInField,
+      cropIdxInFieldToHarvest,
+      cropIdxInFieldToWater,
       playerId,
       children,
       disableEnterAnimation = false,

--- a/src/ui/components/Card/types.ts
+++ b/src/ui/components/Card/types.ts
@@ -24,7 +24,10 @@ export interface CardInteractionProps {
 
 export interface BaseCardProps extends BoxProps, CardInteractionProps {
   cardInstance: CardInstance
-  cardIdx: number
+  cardIdxInHand?: number
+  cropIdxInFieldToWater?: number
+  cropIdxInFieldToHarvest?: number
+  cardIdxInField?: number
   disableEnterAnimation?: boolean
   imageScale?: number
   isFlipped?: boolean

--- a/src/ui/components/Card/useCardInteractions.ts
+++ b/src/ui/components/Card/useCardInteractions.ts
@@ -4,6 +4,7 @@ import { STANDARD_FIELD_SIZE } from '../../../game/config'
 import { lookup } from '../../../game/services/Lookup'
 import { CardType, MatchEvent, MatchState } from '../../../game/types'
 import {
+  assertIsNonNullable,
   isCropCardInstance,
   isPlantableCardInstance,
 } from '../../../game/types/guards'
@@ -17,9 +18,10 @@ import { CardInteractions, CardProps } from './types'
 export const useCardInteractions = (props: CardProps): CardInteractions => {
   const {
     cardInstance,
-    // TODO: cardIdx is overloaded; sometimes it refers to index in the hand,
-    // field, etc. Break it out into discrete named properties.
-    cardIdx,
+    cardIdxInHand,
+    cropIdxInFieldToWater,
+    cropIdxInFieldToHarvest,
+    cardIdxInField,
     playerId,
     onBeforePlay,
     canBeWatered = false,
@@ -51,11 +53,16 @@ export const useCardInteractions = (props: CardProps): CardInteractions => {
       await onBeforePlay()
     }
 
+    assertIsNonNullable(
+      cardIdxInHand,
+      'cardIdxInHand is not a valid hand index'
+    )
+
     switch (cardInstance.type) {
       case CardType.CROP: {
         actorRef.send({
           type: MatchEvent.PLAY_CROP,
-          cardIdxInHand: cardIdx,
+          cardIdxInHand,
           playerId,
         })
         setIsHandInViewport(false)
@@ -66,7 +73,7 @@ export const useCardInteractions = (props: CardProps): CardInteractions => {
       case CardType.WATER: {
         actorRef.send({
           type: MatchEvent.PLAY_WATER,
-          cardIdxInHand: cardIdx,
+          cardIdxInHand,
           playerId,
         })
         setIsHandInViewport(false)
@@ -77,7 +84,7 @@ export const useCardInteractions = (props: CardProps): CardInteractions => {
       case CardType.EVENT: {
         actorRef.send({
           type: MatchEvent.PLAY_EVENT,
-          cardIdxInHand: cardIdx,
+          cardIdxInHand,
           playerId,
         })
 
@@ -87,7 +94,7 @@ export const useCardInteractions = (props: CardProps): CardInteractions => {
       case CardType.TOOL: {
         actorRef.send({
           type: MatchEvent.PLAY_TOOL,
-          cardIdxInHand: cardIdx,
+          cardIdxInHand,
           playerId,
         })
 
@@ -106,27 +113,42 @@ export const useCardInteractions = (props: CardProps): CardInteractions => {
   }
 
   const handleWaterCrop = () => {
+    assertIsNonNullable(
+      cropIdxInFieldToWater,
+      'cropIdxInFieldToWater is not a valid field index'
+    )
+
     actorRef.send({
       type: MatchEvent.SELECT_CROP_TO_WATER,
       playerId,
-      cropIdxInFieldToWater: cardIdx,
+      cropIdxInFieldToWater,
       waterCardInHandIdx: selectedWaterCardInHandIdx,
     })
   }
 
   const handleHarvestCrop = () => {
+    assertIsNonNullable(
+      cropIdxInFieldToHarvest,
+      'cropIdxInFieldToHarvest is not a valid field index'
+    )
+
     actorRef.send({
       type: MatchEvent.HARVEST_CROP,
       playerId,
-      cropIdxInFieldToHarvest: cardIdx,
+      cropIdxInFieldToHarvest,
     })
   }
 
   const handleDiscardCard = () => {
+    assertIsNonNullable(
+      cardIdxInField,
+      'cardIdxInField is not a valid field index'
+    )
+
     actorRef.send({
       type: MatchEvent.DISCARD_CARD_FROM_FIELD,
       playerId,
-      cardIdxInField: cardIdx,
+      cardIdxInField,
     })
   }
 

--- a/src/ui/components/CardQuantityControl/CardQuantityControl.tsx
+++ b/src/ui/components/CardQuantityControl/CardQuantityControl.tsx
@@ -52,7 +52,6 @@ export const CardQuantityControl = ({
       <CardCore
         cardInstance={dummyCardInstance}
         size={cardSize}
-        cardIdx={0}
         playerId=""
         disableEnterAnimation
       />

--- a/src/ui/components/Deck/Deck.test.tsx
+++ b/src/ui/components/Deck/Deck.test.tsx
@@ -9,7 +9,7 @@ import { Deck, DeckProps } from './Deck'
 // NOTE: Mocking out the Card component improves test execution speed
 vi.mock('../Card', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Card: ({ cardInstance, cardIdx, playerId, isFlipped, ...rest }: any) => (
+  Card: ({ cardInstance, playerId, isFlipped, ...rest }: any) => (
     <div {...rest} />
   ),
 }))

--- a/src/ui/components/Deck/Deck.tsx
+++ b/src/ui/components/Deck/Deck.tsx
@@ -64,7 +64,6 @@ export const Deck = ({
           <Card
             key={cardInstance.instanceId}
             cardInstance={cardInstance}
-            cardIdx={idx}
             playerId={player.id}
             position="absolute"
             isFlipped={!(isTopCard && isTopCardSelected)}

--- a/src/ui/components/DiscardPile/DiscardPile.test.tsx
+++ b/src/ui/components/DiscardPile/DiscardPile.test.tsx
@@ -44,8 +44,12 @@ const mockMatch: IMatch = {
 vi.mock('../Card', async () => {
   const React = await import('react')
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const Card = React.forwardRef(function Card({ cardInstance, cardIdx, playerId, size, ...rest }: any, ref: any) {
+  const Card = React.forwardRef(function Card(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { cardInstance, playerId, size, ...rest }: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ref: any
+  ) {
     return (
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       <div ref={ref} data-testid="mock-card" {...rest}>

--- a/src/ui/components/DiscardPile/DiscardPile.tsx
+++ b/src/ui/components/DiscardPile/DiscardPile.tsx
@@ -62,7 +62,6 @@ export const DiscardPile = ({
             <Card
               cardInstance={cardInstance}
               size={cardSize}
-              cardIdx={idx}
               playerId={playerId}
               position="absolute"
               sx={{

--- a/src/ui/components/Field/Field.test.tsx
+++ b/src/ui/components/Field/Field.test.tsx
@@ -27,7 +27,10 @@ import {
 vi.mock('../Card', () => ({
   Card: ({
     cardInstance,
-    cardIdx,
+    cardIdxInHand,
+    cardIdxInField,
+    cropIdxInFieldToHarvest,
+    cropIdxInFieldToWater,
     playerId,
     isFlipped,
     canBeWatered,

--- a/src/ui/components/Field/Field.tsx
+++ b/src/ui/components/Field/Field.tsx
@@ -179,7 +179,9 @@ export const Field = ({
                 tabIndex={0}
                 cardProps={{
                   cardInstance,
-                  cardIdx: fieldIdx,
+                  cardIdxInField: fieldIdx,
+                  cropIdxInFieldToWater: fieldIdx,
+                  cropIdxInFieldToHarvest: fieldIdx,
                   isInField: true,
                   isFocused: isSelected,
                   playerId: player.id,

--- a/src/ui/components/Hand/Hand.test.tsx
+++ b/src/ui/components/Hand/Hand.test.tsx
@@ -30,7 +30,10 @@ vi.mock('../Card/Card', async () => {
         sx,
         // Destructure and ignore props that are not valid for a div
         disableEnterAnimation,
-        cardIdx,
+        cardIdxInField,
+        cardIdxInHand,
+        cropIdxInFieldToHarvest,
+        cropIdxInFieldToWater,
         playerId,
         paperProps,
         onBeforePlay,

--- a/src/ui/components/Hand/Hand.tsx
+++ b/src/ui/components/Hand/Hand.tsx
@@ -183,7 +183,7 @@ export const Hand = ({
             key={cardInstance.instanceId}
             disableEnterAnimation
             cardInstance={cardInstance}
-            cardIdx={idx}
+            cardIdxInHand={idx}
             playerId={playerId}
             size={cardSize}
             paperProps={{

--- a/src/ui/components/PlayedCard/PlayedCard.stories.tsx
+++ b/src/ui/components/PlayedCard/PlayedCard.stories.tsx
@@ -31,7 +31,6 @@ export const PlayedCropCard: Story = {
   args: {
     cardProps: {
       cardInstance: stubCarrot,
-      cardIdx: 0,
       playerId: '',
       playedCard: {
         instance: stubCarrot,
@@ -47,7 +46,6 @@ export const PlayedCropCardWithExtraWater: Story = {
   args: {
     cardProps: {
       cardInstance: stubCarrot,
-      cardIdx: 0,
       playerId: '',
       playedCard: {
         instance: stubCarrot,

--- a/src/ui/components/PlayedCard/PlayedCard.test.tsx
+++ b/src/ui/components/PlayedCard/PlayedCard.test.tsx
@@ -22,7 +22,6 @@ const stubPlayedCrop: IPlayedCrop = {
 const stubCropCardProps: PlayedCropProps['cardProps'] = {
   cardInstance: stubCardInstance,
   playedCard: stubPlayedCrop,
-  cardIdx: 0,
   playerId: '',
 }
 

--- a/src/ui/components/Table/Table.test.tsx
+++ b/src/ui/components/Table/Table.test.tsx
@@ -12,7 +12,10 @@ import { Table, TableProps } from './Table'
 vi.mock('../Card', () => ({
   Card: ({
     cardInstance,
-    cardIdx,
+    cardIdxInHand,
+    cardIdxInField,
+    cropIdxInFieldToHarvest,
+    cropIdxInFieldToWater,
     playerId,
     isFlipped,
     ...rest


### PR DESCRIPTION
## Summary
- Replaces the single overloaded `cardIdx` prop with discrete, named index props (`cardIdxInHand`, `cropIdxInFieldToWater`, `cropIdxInFieldToHarvest`, `cardIdxInField`), each validated at the point of use via `assertIsNonNullable`
- Removes now-unnecessary dummy `cardIdx` values that were previously required at display-only call sites (`Deck`, `DiscardPile`, `CardQuantityControl`) where no index was ever meaningful
- Pure refactor — no intended behavior change

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full affected `vitest` suite passes (84 tests)
- [x] `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)