### PR TITLE
refactor(guards): Replace `assertCurrentPlayer` with `assertIsNonNullable`

### DIFF
--- a/src/game/cards/tools/shovel.test.ts
+++ b/src/game/cards/tools/shovel.test.ts
@@ -8,7 +8,7 @@ import { stubMatch } from '../../../test-utils/stubs/match'
 import { updatePlayer } from '../../reducers/update-player'
 import { createMatchStateMachineContext } from '../../services/Rules/createMatchStateMachineContext'
 import { ShellNotificationType } from '../../types'
-import { assertCurrentPlayer, assertIsNonNullable } from '../../types/guards'
+import { assertIsNonNullable } from '../../types/guards'
 
 import { shovel } from './shovel'
 
@@ -18,7 +18,7 @@ describe('shovel', () => {
       let match = stubMatch()
       const { currentPlayerId } = match
 
-      assertCurrentPlayer(currentPlayerId)
+      assertIsNonNullable(currentPlayerId)
 
       match = updatePlayer(match, currentPlayerId, {
         deck: [stubCarrot, stubPumpkin, stubWater],
@@ -60,7 +60,7 @@ describe('shovel', () => {
       let match = stubMatch()
       const { currentPlayerId } = match
 
-      assertCurrentPlayer(currentPlayerId)
+      assertIsNonNullable(currentPlayerId)
 
       match = updatePlayer(match, currentPlayerId, {
         deck: [stubCarrot, stubPumpkin, stubWater],

--- a/src/game/cards/tools/shovel.ts
+++ b/src/game/cards/tools/shovel.ts
@@ -1,7 +1,7 @@
 import { SHOVEL_CARDS_TO_DRAW } from '../../config'
 import { drawCard } from '../../reducers/draw-card'
 import { CardType, ITool, ShellNotificationType } from '../../types'
-import { assertCurrentPlayer } from '../../types/guards'
+import { assertIsNonNullable } from '../../types/guards'
 
 export const shovel: ITool = Object.freeze<ITool>({
   type: CardType.TOOL,
@@ -20,7 +20,7 @@ export const shovel: ITool = Object.freeze<ITool>({
     let { match } = context
     const { currentPlayerId } = match
 
-    assertCurrentPlayer(currentPlayerId)
+    assertIsNonNullable(currentPlayerId)
 
     match = drawCard(match, currentPlayerId, SHOVEL_CARDS_TO_DRAW)
 

--- a/src/game/cards/tools/sprinkler.test.ts
+++ b/src/game/cards/tools/sprinkler.test.ts
@@ -7,7 +7,7 @@ import { stubMatch } from '../../../test-utils/stubs/match'
 import { updatePlayer } from '../../reducers/update-player'
 import { factory } from '../../services/Factory'
 import { createMatchStateMachineContext } from '../../services/Rules/createMatchStateMachineContext'
-import { assertCurrentPlayer, assertIsNonNullable } from '../../types/guards'
+import { assertIsNonNullable } from '../../types/guards'
 
 import { sprinkler } from './sprinkler'
 
@@ -127,7 +127,7 @@ describe('sprinkler', () => {
         let match = stubMatch()
         const { currentPlayerId } = match
 
-        assertCurrentPlayer(currentPlayerId)
+        assertIsNonNullable(currentPlayerId)
 
         match = updatePlayer(match, currentPlayerId, {
           field: {

--- a/src/game/reducers/increment-player/index.test.ts
+++ b/src/game/reducers/increment-player/index.test.ts
@@ -1,5 +1,6 @@
 import { stubMatch } from '../../../test-utils/stubs/match'
 
+import { MatchStateCorruptError } from '../../services/Rules/errors'
 import { updateMatch } from '../update-match'
 
 import { incrementPlayer } from '.'
@@ -31,6 +32,6 @@ describe('incrementPlayer', () => {
 
     expect(() => {
       incrementPlayer(newMatch)
-    }).toThrowError(TypeError)
+    }).toThrowError(MatchStateCorruptError)
   })
 })

--- a/src/game/reducers/increment-player/index.test.ts
+++ b/src/game/reducers/increment-player/index.test.ts
@@ -1,6 +1,4 @@
 import { stubMatch } from '../../../test-utils/stubs/match'
-
-import { MatchStateCorruptError } from '../../services/Rules/errors'
 import { updateMatch } from '../update-match'
 
 import { incrementPlayer } from '.'
@@ -26,12 +24,12 @@ describe('incrementPlayer', () => {
     expect(newMatch.currentPlayerId).toEqual(player1Id)
   })
 
-  test('throws error is there is no current player', () => {
+  test('throws error if there is no current player', () => {
     const match = stubMatch()
     const newMatch = updateMatch(match, { currentPlayerId: null })
 
     expect(() => {
       incrementPlayer(newMatch)
-    }).toThrowError(MatchStateCorruptError)
+    }).toThrowError(TypeError)
   })
 })

--- a/src/game/services/Lookup/index.ts
+++ b/src/game/services/Lookup/index.ts
@@ -7,7 +7,7 @@ import {
   isWaterCardInstance,
 } from '../../types'
 import {
-  assertCurrentPlayer,
+  assertIsNonNullable,
   isCrop,
   isCropCardInstance,
 } from '../../types/guards'
@@ -186,7 +186,7 @@ export class LookupService {
   nextPlayerIndex = (match: IMatch) => {
     const { currentPlayerId } = match
 
-    assertCurrentPlayer(currentPlayerId)
+    assertIsNonNullable(currentPlayerId)
 
     const playerIds = Object.keys(match.table.players).sort()
     const currentPlayerIdx = playerIds.indexOf(currentPlayerId)

--- a/src/game/services/Rules/state-machine/choosingCardPosition.ts
+++ b/src/game/services/Rules/state-machine/choosingCardPosition.ts
@@ -1,7 +1,7 @@
 import { enqueueActions } from 'xstate'
 
 import { MatchEvent, MatchState, MatchStateGuard } from '../../../types'
-import { assertCurrentPlayer, assertIsNonNullable } from '../../../types/guards'
+import { assertIsNonNullable } from '../../../types/guards'
 import { botLogic } from '../../BotLogic'
 
 import { recordCardPlayEvents } from './reducers'
@@ -28,7 +28,7 @@ export const choosingCardPositon: RulesMachineConfig['states'] = {
           const { currentPlayerId, sessionOwnerPlayerId } = match
           const { playerId, cardIdxInHand } = event
 
-          assertCurrentPlayer(currentPlayerId)
+          assertIsNonNullable(currentPlayerId)
 
           if (currentPlayerId !== sessionOwnerPlayerId) {
             const openFieldPositionIdx = botLogic.getOpenFieldPosition(

--- a/src/game/services/Rules/state-machine/createMachine.ts
+++ b/src/game/services/Rules/state-machine/createMachine.ts
@@ -7,7 +7,7 @@ import {
   MatchMachineContext,
   MatchStateGuard,
 } from '../../../types'
-import { assertCurrentPlayer } from '../../../types/guards'
+import { assertIsNonNullable } from '../../../types/guards'
 import { lookup } from '../../Lookup'
 
 export const { createMachine } = setup({
@@ -23,7 +23,7 @@ export const { createMachine } = setup({
     }) => {
       const { currentPlayerId } = match
 
-      assertCurrentPlayer(currentPlayerId)
+      assertIsNonNullable(currentPlayerId)
 
       switch (event.type) {
         case MatchEvent.SELECT_CROP_TO_WATER: {

--- a/src/game/services/Rules/state-machine/performingBotCropHarvestingState.ts
+++ b/src/game/services/Rules/state-machine/performingBotCropHarvestingState.ts
@@ -1,7 +1,7 @@
 import { enqueueActions } from 'xstate'
 
 import { MatchEvent, MatchState, ShellNotificationType } from '../../../types'
-import { assertCurrentPlayer, assertIsPlayedCrop } from '../../../types/guards'
+import { assertIsNonNullable, assertIsPlayedCrop } from '../../../types/guards'
 import { harvestCrop } from '../../../reducers/harvest-crop'
 import { lookup } from '../../Lookup'
 
@@ -27,7 +27,7 @@ export const performingBotCropHarvestingState: RulesMachineConfig['states'] = {
       }) => {
         const { currentPlayerId } = match
 
-        assertCurrentPlayer(currentPlayerId)
+        assertIsNonNullable(currentPlayerId)
 
         if (cropCardIdxToHarvest !== undefined) {
           const player = lookup.getPlayer(match, currentPlayerId)

--- a/src/game/services/Rules/state-machine/performingBotCropWateringState.ts
+++ b/src/game/services/Rules/state-machine/performingBotCropWateringState.ts
@@ -9,7 +9,7 @@ import {
   isWaterCardInstance,
   ShellNotificationType,
 } from '../../../types'
-import { assertCurrentPlayer, assertIsPlayedCrop } from '../../../types/guards'
+import { assertIsNonNullable, assertIsPlayedCrop } from '../../../types/guards'
 import { MatchStateCorruptError } from '../errors'
 import { lookup } from '../../Lookup'
 
@@ -33,7 +33,7 @@ export const performingBotCropWateringState: RulesMachineConfig['states'] = {
       }) => {
         const { currentPlayerId } = match
 
-        assertCurrentPlayer(currentPlayerId)
+        assertIsNonNullable(currentPlayerId)
 
         const player = lookup.getPlayer(match, currentPlayerId)
         const waterCardInHandIdx = player.hand.findIndex(cardInstance => {

--- a/src/game/services/Rules/state-machine/performingBotSetupActionState.ts
+++ b/src/game/services/Rules/state-machine/performingBotSetupActionState.ts
@@ -5,7 +5,7 @@ import { BOT_ACTION_DELAY } from '../../../config'
 import { incrementPlayer } from '../../../reducers/increment-player'
 import { moveCardFromHandToField } from '../../../reducers/move-card-from-hand-to-field'
 import { MatchEvent, MatchState, MatchStateGuard } from '../../../types'
-import { assertCurrentPlayer } from '../../../types/guards'
+import { assertIsNonNullable } from '../../../types/guards'
 import { botLogic } from '../../BotLogic'
 import { lookup } from '../../Lookup'
 import { GameStateCorruptError, MatchStateCorruptError } from '../errors'
@@ -36,7 +36,7 @@ export const performingBotSetupActionState: RulesMachineConfig['states'] = {
 
             const { currentPlayerId } = match
 
-            assertCurrentPlayer(currentPlayerId)
+            assertIsNonNullable(currentPlayerId)
 
             const player = lookup.getPlayer(match, currentPlayerId)
             const hasBotCompletedSetup =
@@ -99,7 +99,7 @@ export const performingBotSetupActionState: RulesMachineConfig['states'] = {
           const { cardIdxInHand } = event
           const { currentPlayerId } = match
 
-          assertCurrentPlayer(currentPlayerId)
+          assertIsNonNullable(currentPlayerId)
 
           match = recordCardPlayEvents(match, event)
 
@@ -144,7 +144,7 @@ export const performingBotSetupActionState: RulesMachineConfig['states'] = {
 
             const { currentPlayerId } = match
 
-            assertCurrentPlayer(currentPlayerId)
+            assertIsNonNullable(currentPlayerId)
 
             match = recordCardPlayEvents(match, event)
             match = moveCardFromHandToField(
@@ -174,7 +174,7 @@ export const performingBotSetupActionState: RulesMachineConfig['states'] = {
     entry: enqueueActions(({ context: { match }, enqueue }) => {
       const { currentPlayerId } = match
 
-      assertCurrentPlayer(currentPlayerId)
+      assertIsNonNullable(currentPlayerId)
 
       match = incrementPlayer(match)
 

--- a/src/game/services/Rules/state-machine/performingBotTurnActionState.ts
+++ b/src/game/services/Rules/state-machine/performingBotTurnActionState.ts
@@ -12,11 +12,7 @@ import {
   MatchState,
   isToolCardInstance,
 } from '../../../types'
-import {
-  assertCurrentPlayer,
-  assertIsNonNullable,
-  assertIsToolCardId,
-} from '../../../types/guards'
+import { assertIsNonNullable, assertIsToolCardId } from '../../../types/guards'
 import { botLogic } from '../../BotLogic'
 import { lookup } from '../../Lookup'
 import { GameStateCorruptError, MatchStateCorruptError } from '../errors'
@@ -66,7 +62,7 @@ export const performingBotTurnActionState: RulesMachineConfig['states'] = {
 
                   const { currentPlayerId } = match
 
-                  assertCurrentPlayer(currentPlayerId)
+                  assertIsNonNullable(currentPlayerId)
 
                   const previousTurnStateForCurrentPlayer =
                     previousTurnMatchState.table.players[currentPlayerId]
@@ -155,7 +151,7 @@ export const performingBotTurnActionState: RulesMachineConfig['states'] = {
               if (areCropsToPlay) {
                 const { currentPlayerId } = match
 
-                assertCurrentPlayer(currentPlayerId)
+                assertIsNonNullable(currentPlayerId)
 
                 const cropIdxsInPlayerHand = lookup.findCropIndexesInPlayerHand(
                   match,
@@ -205,7 +201,7 @@ export const performingBotTurnActionState: RulesMachineConfig['states'] = {
               if (areCropsToPlay) {
                 const { currentPlayerId } = match
 
-                assertCurrentPlayer(currentPlayerId)
+                assertIsNonNullable(currentPlayerId)
 
                 const cropIdxsInPlayerHand = lookup.findCropIndexesInPlayerHand(
                   match,
@@ -256,7 +252,7 @@ export const performingBotTurnActionState: RulesMachineConfig['states'] = {
           withBotErrorHandling(({ context: { botState, match }, enqueue }) => {
             const { currentPlayerId } = match
 
-            assertCurrentPlayer(currentPlayerId)
+            assertIsNonNullable(currentPlayerId)
 
             const fieldCropIndicesToWaterDuringTurn =
               botLogic.getCropCardIndicesToWater(match, currentPlayerId)
@@ -305,7 +301,7 @@ export const performingBotTurnActionState: RulesMachineConfig['states'] = {
             if (areEventCardsToPlay) {
               const { currentPlayerId } = match
 
-              assertCurrentPlayer(currentPlayerId)
+              assertIsNonNullable(currentPlayerId)
 
               const eventCardIdxToPlay = botLogic.getEventCardIndexToPlay(
                 match,
@@ -347,7 +343,7 @@ export const performingBotTurnActionState: RulesMachineConfig['states'] = {
             if (areToolsToPlay) {
               const { currentPlayerId } = match
 
-              assertCurrentPlayer(currentPlayerId)
+              assertIsNonNullable(currentPlayerId)
 
               const toolCardIdxToPlay = botLogic.getToolCardIndexToPlay(
                 match,
@@ -411,7 +407,7 @@ export const performingBotTurnActionState: RulesMachineConfig['states'] = {
           withBotErrorHandling(({ context: { botState, match }, enqueue }) => {
             const { currentPlayerId } = match
 
-            assertCurrentPlayer(currentPlayerId)
+            assertIsNonNullable(currentPlayerId)
 
             const cropCardIndicesToHarvest =
               botLogic.getCropCardIndicesToHarvest(match, currentPlayerId)

--- a/src/game/services/Rules/state-machine/playingEventCard.ts
+++ b/src/game/services/Rules/state-machine/playingEventCard.ts
@@ -3,8 +3,8 @@ import { assertEvent, enqueueActions } from 'xstate'
 import { moveFromHandToDiscardPile } from '../../../reducers/move-from-hand-to-discard-pile'
 import { MatchEvent, MatchState, ShellNotificationType } from '../../../types'
 import {
-  assertCurrentPlayer,
   assertIsEventCardInstance,
+  assertIsNonNullable,
 } from '../../../types/guards'
 import { lookup } from '../../Lookup'
 
@@ -41,7 +41,7 @@ export const playingEventCard: RulesMachineConfig['states'] = {
         )
 
         assertIsEventCardInstance(cardInstance)
-        assertCurrentPlayer(currentPlayerId)
+        assertIsNonNullable(currentPlayerId)
 
         triggerNotification({
           type: ShellNotificationType.EVENT_CARD_PLAYED,

--- a/src/game/services/Rules/state-machine/playingToolCard.ts
+++ b/src/game/services/Rules/state-machine/playingToolCard.ts
@@ -3,7 +3,7 @@ import { assertEvent, enqueueActions } from 'xstate'
 import { moveFromHandToDiscardPile } from '../../../reducers/move-from-hand-to-discard-pile'
 import { MatchEvent, MatchState, ShellNotificationType } from '../../../types'
 import {
-  assertCurrentPlayer,
+  assertIsNonNullable,
   assertIsToolCardInstance,
 } from '../../../types/guards'
 import { lookup } from '../../Lookup'
@@ -44,7 +44,7 @@ export const playingToolCard: RulesMachineConfig['states'] = {
         )
 
         assertIsToolCardInstance(cardInstance)
-        assertCurrentPlayer(currentPlayerId)
+        assertIsNonNullable(currentPlayerId)
 
         if (
           !cardInstance.isPlantable ||

--- a/src/game/services/Rules/state-machine/reducers.ts
+++ b/src/game/services/Rules/state-machine/reducers.ts
@@ -6,7 +6,7 @@ import {
   MatchEventPayload,
   MatchEventPayloadKey,
 } from '../../../types'
-import { assertCurrentPlayer, assertIsNonNullable } from '../../../types/guards'
+import { assertIsNonNullable } from '../../../types/guards'
 import { lookup } from '../../Lookup'
 
 /**
@@ -36,7 +36,7 @@ export const recordCardPlayEvents = (
     case MatchEvent.SELECT_CARD_POSITION: {
       const { currentPlayerId } = match
 
-      assertCurrentPlayer(currentPlayerId)
+      assertIsNonNullable(currentPlayerId)
 
       match = recordCardsPlayedDuringTurn(currentPlayerId, event.cardIdxInHand)
 
@@ -48,7 +48,7 @@ export const recordCardPlayEvents = (
     case MatchEvent.PLAY_WATER: {
       const { currentPlayerId } = match
 
-      assertCurrentPlayer(currentPlayerId)
+      assertIsNonNullable(currentPlayerId)
 
       const player = lookup.getPlayer(match, currentPlayerId)
       const card = player.hand[event.cardIdxInHand]

--- a/src/game/services/Rules/state-machine/waitingForPlayerTurnActionState.ts
+++ b/src/game/services/Rules/state-machine/waitingForPlayerTurnActionState.ts
@@ -15,7 +15,7 @@ import {
   MatchState,
   ShellNotificationType,
 } from '../../../types'
-import { assertCurrentPlayer, isPlayedCrop } from '../../../types/guards'
+import { assertIsNonNullable, isPlayedCrop } from '../../../types/guards'
 import { lookup } from '../../Lookup'
 import { InvalidCardError, PlayerOutOfFundsError } from '../errors'
 import { rules } from '..'
@@ -124,7 +124,7 @@ export const waitingForPlayerTurnActionState: RulesMachineConfig['states'] = {
               match = incrementPlayer(match)
               const { currentPlayerId } = match
 
-              assertCurrentPlayer(currentPlayerId)
+              assertIsNonNullable(currentPlayerId)
 
               const previousTurnStateForCurrentPlayer = lookup.getPlayer(
                 previousTurnMatchState,
@@ -168,7 +168,7 @@ export const waitingForPlayerTurnActionState: RulesMachineConfig['states'] = {
             case MatchEvent.OPERATION_ABORTED: {
               const { currentPlayerId } = match
 
-              assertCurrentPlayer(currentPlayerId)
+              assertIsNonNullable(currentPlayerId)
 
               match = removeTurnCardsPlayed(match, currentPlayerId, 1)
 
@@ -181,7 +181,7 @@ export const waitingForPlayerTurnActionState: RulesMachineConfig['states'] = {
           if (error instanceof PlayerOutOfFundsError) {
             const { currentPlayerId } = match
 
-            assertCurrentPlayer(currentPlayerId)
+            assertIsNonNullable(currentPlayerId)
 
             enqueue.raise({
               type: MatchEvent.PLAYER_RAN_OUT_OF_FUNDS,

--- a/src/game/types/guards/index.test.ts
+++ b/src/game/types/guards/index.test.ts
@@ -267,16 +267,6 @@ describe('Type Guards', () => {
     })
   })
 
-  describe('assertCurrentPlayer', () => {
-    it('does not throw for valid string', () => {
-      expect(() => guards.assertCurrentPlayer('player1')).not.toThrow()
-    })
-
-    it('throws TypeError for null', () => {
-      expect(() => guards.assertCurrentPlayer(null)).toThrow(TypeError)
-    })
-  })
-
   describe('assertStringIsMatchState', () => {
     it('does not throw for valid MatchState string', () => {
       expect(() =>

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -206,7 +206,7 @@ export function assertIsNonNullable<T>(
   message = `${String(obj)} is null or undefined`
 ): asserts obj is NonNullable<T> {
   if (obj === undefined || obj === null) {
-    throw new MatchStateCorruptError(message)
+    throw new TypeError(message)
   }
 }
 

--- a/src/game/types/guards/index.ts
+++ b/src/game/types/guards/index.ts
@@ -203,7 +203,7 @@ export const isCard = (obj: unknown): obj is ICard => {
 
 export function assertIsNonNullable<T>(
   obj: T,
-  message = `${String(obj)} is not a valid card ID`
+  message = `${String(obj)} is null or undefined`
 ): asserts obj is NonNullable<T> {
   if (obj === undefined || obj === null) {
     throw new MatchStateCorruptError(message)
@@ -237,15 +237,6 @@ export function assertIsToolCardInstance(
 ): asserts card is ToolInstance {
   if (!isToolCardInstance(card)) {
     throw new MatchStateCorruptError(`${card.id} is not a tool card`)
-  }
-}
-
-// TODO: Replace all uses of this with assertIsNonNullable
-export function assertCurrentPlayer(
-  currentPlayerId: string | null
-): asserts currentPlayerId is string {
-  if (currentPlayerId === null) {
-    throw new TypeError('currentPlayerId must not be null')
   }
 }
 

--- a/src/ui/components/TurnControl/TurnControl.tsx
+++ b/src/ui/components/TurnControl/TurnControl.tsx
@@ -15,7 +15,7 @@ import { funAnimalName } from 'fun-animal-names'
 import { ReactNode, useContext } from 'react'
 
 import { MatchEvent, MatchState, IMatch } from '../../../game/types'
-import { assertCurrentPlayer } from '../../../game/types/guards'
+import { assertIsNonNullable } from '../../../game/types/guards'
 import { lookup } from '../../../game/services/Lookup'
 import { MatchStateCorruptError } from '../../../game/services/Rules/errors'
 import { formatNumber } from '../../../lib/formatting/numbers'
@@ -117,7 +117,7 @@ export const TurnControl = ({ match }: TurnControlProps) => {
     }
 
     case MatchState.PERFORMING_BOT_TURN_ACTION: {
-      assertCurrentPlayer(currentPlayerId)
+      assertIsNonNullable(currentPlayerId)
 
       stateInfo = `${funAnimalName(currentPlayerId)}'s turn`
 
@@ -125,7 +125,7 @@ export const TurnControl = ({ match }: TurnControlProps) => {
     }
 
     case MatchState.PERFORMING_BOT_SETUP_ACTION: {
-      assertCurrentPlayer(currentPlayerId)
+      assertIsNonNullable(currentPlayerId)
 
       stateInfo = `${funAnimalName(currentPlayerId)} is setting their field up`
 
@@ -133,7 +133,7 @@ export const TurnControl = ({ match }: TurnControlProps) => {
     }
 
     case MatchState.PERFORMING_BOT_CROP_WATERING: {
-      assertCurrentPlayer(currentPlayerId)
+      assertIsNonNullable(currentPlayerId)
 
       // TODO: This message never seems to actually appear in the game when the bot is watering crops. This may be due to a timing issue (it may be shown faster than it can be seen).
       stateInfo = `${funAnimalName(currentPlayerId)} is watering crops`


### PR DESCRIPTION
### What this PR does

- Replaces all usages of `assertCurrentPlayer` across the codebase with `assertIsNonNullable` and removes `assertCurrentPlayer`.
- Updates `assertIsNonNullable` to throw a `TypeError` when given a `null` or `undefined` value.

### How this change can be validated
- Run `npm test` to verify all test suites pass.
- Run `npm run check:lint` and `npm run check:types` to verify zero lint and type errors.

### Questions or concerns about this change
- None.

### Additional information
- N/A