### PR TITLE
feat(ui): add global NotificationContext and refactor notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import CssBaseline from '@mui/material/CssBaseline'
 import ThemeProvider from '@mui/material/styles/ThemeProvider'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 
+import { NotificationProvider } from './ui/context/NotificationContext'
 import { ErrorBoundary } from './ui/components/ErrorBoundary'
 import { BuildDeck } from './ui/pages/BuildDeck'
 import { MainMenu } from './ui/pages/MainMenu'
@@ -32,7 +33,9 @@ export const App = () => {
   return (
     <ThemeProvider theme={lightTheme}>
       <CssBaseline />
-      <RouterProvider router={router} />
+      <NotificationProvider>
+        <RouterProvider router={router} />
+      </NotificationProvider>
     </ThemeProvider>
   )
 }

--- a/src/ui/components/Match/Match.tsx
+++ b/src/ui/components/Match/Match.tsx
@@ -15,8 +15,6 @@ import { ui } from '../../img'
 import { Table } from '../Table'
 import { TurnControl } from '../TurnControl'
 
-import { Snackbar } from '../Snackbar'
-
 import { ActorContext } from './ActorContext'
 import { ShellContext } from './ShellContext'
 import { MatchProps } from './types'
@@ -40,7 +38,6 @@ const MatchCore = ({
     shellContextValue,
     showGameOver,
     showHand,
-    snackbarProps,
   } = useMatch({ playerSeeds, userPlayerId })
 
   const { winner } = match
@@ -103,7 +100,6 @@ const MatchCore = ({
           </DialogActions>
         </Dialog>
       </Container>
-      <Snackbar {...snackbarProps} />
     </ShellContext.Provider>
   )
 }

--- a/src/ui/components/Match/useMatch.test.ts
+++ b/src/ui/components/Match/useMatch.test.ts
@@ -5,14 +5,20 @@ import { MatchState, MatchEvent, IPlayerSeed } from '../../../game/types'
 import { useMatchRules } from '../../hooks/useMatchRules'
 import { stubMatch } from '../../../test-utils/stubs/match'
 
-import { emptyNotificationMessage } from '../Snackbar'
-
 import { ActorContext } from './ActorContext'
 import { useMatch } from './useMatch'
 
 // Mock dependencies
 vi.mock('../../hooks/useMatchRules')
 vi.mock('./ActorContext')
+
+const showNotificationMock = vi.fn()
+
+vi.mock('../../context/NotificationContext', () => ({
+  useNotification: () => ({
+    showNotification: showNotificationMock,
+  }),
+}))
 
 describe('useMatch', () => {
   // Mock player seeds and user ID
@@ -37,6 +43,7 @@ describe('useMatch', () => {
 
   beforeEach(() => {
     // Setup mocks
+    vi.clearAllMocks()
     vi.mocked(ActorContext.useActorRef).mockReturnValue(mockActorRef)
     vi.mocked(useMatchRules).mockReturnValue({
       match: {
@@ -219,7 +226,7 @@ describe('useMatch', () => {
     expect(result.current.showHand).toBe(true)
   })
 
-  it('should update snackbar props when showNotification is called', () => {
+  it('should delegate showNotification to NotificationContext', () => {
     const { result } = renderHook(() =>
       useMatch({
         playerSeeds: mockPlayerSeeds,
@@ -234,32 +241,7 @@ describe('useMatch', () => {
       )
     })
 
-    expect(result.current.snackbarProps.message).toBe('Test message')
-    expect(result.current.snackbarProps.severity).toBe('success')
-  })
-
-  it('should clear snackbar message when onClose is called', () => {
-    const { result } = renderHook(() =>
-      useMatch({
-        playerSeeds: mockPlayerSeeds,
-        userPlayerId: mockUserPlayerId,
-      })
-    )
-
-    act(() => {
-      result.current.shellContextValue.showNotification(
-        'Test message',
-        'success'
-      )
-    })
-
-    expect(result.current.snackbarProps.message).toBe('Test message')
-
-    act(() => {
-      result.current.snackbarProps.onClose()
-    })
-
-    expect(result.current.snackbarProps.message).toBe(emptyNotificationMessage)
+    expect(showNotificationMock).toHaveBeenCalledWith('Test message', 'success')
   })
 
   it('should update isHandInViewport when setIsHandInViewport is called', () => {

--- a/src/ui/components/Match/useMatch.ts
+++ b/src/ui/components/Match/useMatch.ts
@@ -51,7 +51,7 @@ export const useMatch = ({
     [setIsBlockingOperationExecuting]
   )
 
-  const { showNotification, snackbarProps } = useSnackbar({ actorRef, match })
+  const { showNotification } = useSnackbar({ actorRef, match })
 
   const [selectedHandCardIdx, _setSelectedHandCardIdx] =
     useState(deselectedHandIdx)
@@ -111,6 +111,5 @@ export const useMatch = ({
     shellContextValue,
     showGameOver,
     showHand,
-    snackbarProps,
   }
 }

--- a/src/ui/components/Match/useSnackbar.test.ts
+++ b/src/ui/components/Match/useSnackbar.test.ts
@@ -21,8 +21,6 @@ import {
 import { stubMatch } from '../../../test-utils/stubs/match'
 import { stubPlayer1, stubPlayer2 } from '../../../test-utils/stubs/players'
 
-import { emptyNotificationMessage } from '../Snackbar'
-
 import { ActorContext } from './ActorContext'
 import { useSnackbar } from './useSnackbar'
 
@@ -39,11 +37,20 @@ vi.mock('./ActorContext', () => ({
   },
 }))
 
+const showNotificationMock = vi.fn()
+
+vi.mock('../../context/NotificationContext', () => ({
+  useNotification: () => ({
+    showNotification: showNotificationMock,
+  }),
+}))
+
 describe('useSnackbar Hook', () => {
   let actorRef: ReturnType<typeof ActorContext.useActorRef>
   let match: IMatch
 
   beforeEach(() => {
+    vi.clearAllMocks()
     actorRef = { send: vi.fn() } as unknown as ReturnType<
       typeof ActorContext.useActorRef
     >
@@ -56,15 +63,15 @@ describe('useSnackbar Hook', () => {
     ).mockReturnValue('Fun Animal')
   })
 
-  it('should initialize with an empty snackbar message', () => {
-    const { result } = renderHook(() =>
+  it('should initialize without firing notifications', () => {
+    renderHook(() =>
       useSnackbar({
         actorRef,
         match,
       })
     )
 
-    expect(result.current.snackbarProps.message).toBe('')
+    expect(showNotificationMock).not.toHaveBeenCalled()
   })
 
   it('should call actorRef.send on mount', () => {
@@ -92,7 +99,7 @@ describe('useSnackbar Hook', () => {
     ])(
       'shows the correct CARDS_DRAWN notification message when session owner draws $howMany cards',
       ({ howMany, expectedNotification }) => {
-        const { result } = renderHook(() =>
+        renderHook(() =>
           useSnackbar({
             actorRef,
             match,
@@ -119,10 +126,10 @@ describe('useSnackbar Hook', () => {
           })
         })
 
-        expect(result.current.snackbarProps.message).toEqual(
-          expectedNotification
+        expect(showNotificationMock).toHaveBeenLastCalledWith(
+          expectedNotification,
+          'success'
         )
-        expect(result.current.snackbarProps.severity).toEqual('success')
       }
     )
 
@@ -133,7 +140,7 @@ describe('useSnackbar Hook', () => {
       'shows the correct CARDS_DRAWN notification message when $howMany cards are drawn by non-session owner',
       ({ howMany, expectedNotification }) => {
         match = updateMatch(match, { sessionOwnerPlayerId: stubPlayer2.id })
-        const { result } = renderHook(() =>
+        renderHook(() =>
           useSnackbar({
             actorRef,
             match,
@@ -160,15 +167,15 @@ describe('useSnackbar Hook', () => {
           })
         })
 
-        expect(result.current.snackbarProps.message).toEqual(
-          expectedNotification
+        expect(showNotificationMock).toHaveBeenLastCalledWith(
+          expectedNotification,
+          'warning'
         )
-        expect(result.current.snackbarProps.severity).toEqual('warning')
       }
     )
 
     it('should show the correct CROP_HARVESTED notification message when session owner', () => {
-      const { result } = renderHook(() =>
+      renderHook(() =>
         useSnackbar({
           actorRef,
           match,
@@ -194,25 +201,19 @@ describe('useSnackbar Hook', () => {
         })
       })
 
-      expect(result.current.snackbarProps.message).toEqual(
-        `You harvested and sold a ${carrot.name}`
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `You harvested and sold a ${carrot.name}`,
+        'success'
       )
-      expect(result.current.snackbarProps.severity).toEqual('success')
     })
 
     it('should show the correct CROP_HARVESTED notification message when not session owner', () => {
       match = updateMatch(match, { sessionOwnerPlayerId: stubPlayer2.id })
-      const { result } = renderHook(() =>
+      renderHook(() =>
         useSnackbar({
           actorRef,
           match,
         })
-      )
-
-      const showNotification = vi.fn()
-
-      vi.spyOn(result.current, 'showNotification').mockImplementation(
-        showNotification
       )
 
       const payload: ShellNotificationPayload[ShellNotificationType.CROP_HARVESTED] =
@@ -234,14 +235,14 @@ describe('useSnackbar Hook', () => {
         })
       })
 
-      expect(result.current.snackbarProps.message).toEqual(
-        `Fun Animal harvested and sold a ${carrot.name}`
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `Fun Animal harvested and sold a ${carrot.name}`,
+        'warning'
       )
-      expect(result.current.snackbarProps.severity).toEqual('warning')
     })
 
     it('should show the correct CROP_WATERED notification message when session owner', () => {
-      const { result } = renderHook(() =>
+      renderHook(() =>
         useSnackbar({
           actorRef,
           match,
@@ -267,25 +268,19 @@ describe('useSnackbar Hook', () => {
         })
       })
 
-      expect(result.current.snackbarProps.message).toEqual(
-        `You watered your ${carrot.name}`
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `You watered your ${carrot.name}`,
+        'info'
       )
-      expect(result.current.snackbarProps.severity).toEqual('info')
     })
 
     it('should show the correct CROP_WATERED notification message when not session owner', () => {
       match = updateMatch(match, { sessionOwnerPlayerId: stubPlayer2.id })
-      const { result } = renderHook(() =>
+      renderHook(() =>
         useSnackbar({
           actorRef,
           match,
         })
-      )
-
-      const showNotification = vi.fn()
-
-      vi.spyOn(result.current, 'showNotification').mockImplementation(
-        showNotification
       )
 
       const payload: ShellNotificationPayload[ShellNotificationType.CROP_WATERED] =
@@ -307,14 +302,14 @@ describe('useSnackbar Hook', () => {
         })
       })
 
-      expect(result.current.snackbarProps.message).toEqual(
-        `Fun Animal watered their ${carrot.name}`
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `Fun Animal watered their ${carrot.name}`,
+        'info'
       )
-      expect(result.current.snackbarProps.severity).toEqual('info')
     })
 
     it('should show the correct EVENT_CARD_PLAYED notification message when session owner', () => {
-      const { result } = renderHook(() =>
+      renderHook(() =>
         useSnackbar({
           actorRef,
           match,
@@ -340,25 +335,19 @@ describe('useSnackbar Hook', () => {
         })
       })
 
-      expect(result.current.snackbarProps.message).toEqual(
-        `You played ${payload.eventCard.name}`
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `You played ${payload.eventCard.name}`,
+        'info'
       )
-      expect(result.current.snackbarProps.severity).toEqual('info')
     })
 
     it('should show the correct EVENT_CARD_PLAYED notification message when not session owner', () => {
       match = updateMatch(match, { sessionOwnerPlayerId: stubPlayer2.id })
-      const { result } = renderHook(() =>
+      renderHook(() =>
         useSnackbar({
           actorRef,
           match,
         })
-      )
-
-      const showNotification = vi.fn()
-
-      vi.spyOn(result.current, 'showNotification').mockImplementation(
-        showNotification
       )
 
       const payload: ShellNotificationPayload[ShellNotificationType.EVENT_CARD_PLAYED] =
@@ -380,167 +369,148 @@ describe('useSnackbar Hook', () => {
         })
       })
 
-      expect(result.current.snackbarProps.message).toEqual(
-        `Fun Animal played ${payload.eventCard.name}`
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `Fun Animal played ${payload.eventCard.name}`,
+        'info'
       )
-      expect(result.current.snackbarProps.severity).toEqual('info')
+    })
+
+    it('should show the correct TOOL_CARD_PLAYED notification message when session owner', () => {
+      renderHook(() =>
+        useSnackbar({
+          actorRef,
+          match,
+        })
+      )
+
+      const payload: ShellNotificationPayload[ShellNotificationType.TOOL_CARD_PLAYED] =
+        {
+          toolCard: stubShovel,
+        }
+
+      const send = actorRef.send as unknown as MockInstance<
+        (event: MatchEvents) => void
+      >
+      const matchEventPayload = send.mock.calls[0]![0]
+
+      assertEvent(matchEventPayload, MatchEvent.SET_SHELL)
+
+      act(() => {
+        matchEventPayload.shell.triggerNotification({
+          type: ShellNotificationType.TOOL_CARD_PLAYED,
+          payload,
+        })
+      })
+
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `You played ${payload.toolCard.name}`,
+        'info'
+      )
+    })
+
+    it('should show the correct TOOL_CARD_PLAYED notification message when not session owner', () => {
+      match = updateMatch(match, { sessionOwnerPlayerId: stubPlayer2.id })
+      renderHook(() =>
+        useSnackbar({
+          actorRef,
+          match,
+        })
+      )
+
+      const payload: ShellNotificationPayload[ShellNotificationType.TOOL_CARD_PLAYED] =
+        {
+          toolCard: stubShovel,
+        }
+
+      const send = actorRef.send as unknown as MockInstance<
+        (event: MatchEvents) => void
+      >
+      const matchEventPayload = send.mock.calls[0]![0]
+
+      assertEvent(matchEventPayload, MatchEvent.SET_SHELL)
+
+      act(() => {
+        matchEventPayload.shell.triggerNotification({
+          type: ShellNotificationType.TOOL_CARD_PLAYED,
+          payload,
+        })
+      })
+
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `Fun Animal played ${payload.toolCard.name}`,
+        'info'
+      )
+    })
+
+    it('should show the correct CARD_DISCARDED notification message when player discards a planted card', () => {
+      renderHook(() =>
+        useSnackbar({
+          actorRef,
+          match,
+        })
+      )
+
+      const payload: ShellNotificationPayload[ShellNotificationType.CARD_DISCARDED] =
+        {
+          cardDiscarded: stubSprinkler,
+        }
+
+      const send = actorRef.send as unknown as MockInstance<
+        (event: MatchEvents) => void
+      >
+      const matchEventPayload = send.mock.calls[0]![0]
+
+      assertEvent(matchEventPayload, MatchEvent.SET_SHELL)
+
+      act(() => {
+        matchEventPayload.shell.triggerNotification({
+          type: ShellNotificationType.CARD_DISCARDED,
+          payload,
+        })
+      })
+
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `You discarded ${payload.cardDiscarded.name}`,
+        'info'
+      )
+    })
+
+    it('should show the correct CARD_DISCARDED notification message when non-session owner discards a planted card', () => {
+      match = updateMatch(match, { sessionOwnerPlayerId: stubPlayer2.id })
+      renderHook(() =>
+        useSnackbar({
+          actorRef,
+          match,
+        })
+      )
+
+      const payload: ShellNotificationPayload[ShellNotificationType.CARD_DISCARDED] =
+        {
+          cardDiscarded: stubSprinkler,
+        }
+
+      const send = actorRef.send as unknown as MockInstance<
+        (event: MatchEvents) => void
+      >
+      const matchEventPayload = send.mock.calls[0]![0]
+
+      assertEvent(matchEventPayload, MatchEvent.SET_SHELL)
+
+      act(() => {
+        matchEventPayload.shell.triggerNotification({
+          type: ShellNotificationType.CARD_DISCARDED,
+          payload,
+        })
+      })
+
+      expect(showNotificationMock).toHaveBeenLastCalledWith(
+        `Fun Animal discarded ${payload.cardDiscarded.name}`,
+        'info'
+      )
     })
   })
 
-  it('should show the correct TOOL_CARD_PLAYED notification message when session owner', () => {
-    const { result } = renderHook(() =>
-      useSnackbar({
-        actorRef,
-        match,
-      })
-    )
-
-    const payload: ShellNotificationPayload[ShellNotificationType.TOOL_CARD_PLAYED] =
-      {
-        toolCard: stubShovel,
-      }
-
-    const send = actorRef.send as unknown as MockInstance<
-      (event: MatchEvents) => void
-    >
-    const matchEventPayload = send.mock.calls[0]![0]
-
-    assertEvent(matchEventPayload, MatchEvent.SET_SHELL)
-
-    act(() => {
-      matchEventPayload.shell.triggerNotification({
-        type: ShellNotificationType.TOOL_CARD_PLAYED,
-        payload,
-      })
-    })
-
-    expect(result.current.snackbarProps.message).toEqual(
-      `You played ${payload.toolCard.name}`
-    )
-    expect(result.current.snackbarProps.severity).toEqual('info')
-  })
-
-  it('should show the correct TOOL_CARD_PLAYED notification message when not session owner', () => {
-    match = updateMatch(match, { sessionOwnerPlayerId: stubPlayer2.id })
-    const { result } = renderHook(() =>
-      useSnackbar({
-        actorRef,
-        match,
-      })
-    )
-
-    const showNotification = vi.fn()
-
-    vi.spyOn(result.current, 'showNotification').mockImplementation(
-      showNotification
-    )
-
-    const payload: ShellNotificationPayload[ShellNotificationType.TOOL_CARD_PLAYED] =
-      {
-        toolCard: stubShovel,
-      }
-
-    const send = actorRef.send as unknown as MockInstance<
-      (event: MatchEvents) => void
-    >
-    const matchEventPayload = send.mock.calls[0]![0]
-
-    assertEvent(matchEventPayload, MatchEvent.SET_SHELL)
-
-    act(() => {
-      matchEventPayload.shell.triggerNotification({
-        type: ShellNotificationType.TOOL_CARD_PLAYED,
-        payload,
-      })
-    })
-
-    expect(result.current.snackbarProps.message).toEqual(
-      `Fun Animal played ${payload.toolCard.name}`
-    )
-    expect(result.current.snackbarProps.severity).toEqual('info')
-  })
-
-  it('should show the correct CARD_DISCARDED notification message when player discards a planted card', () => {
-    match = updateMatch(match, { sessionOwnerPlayerId: stubPlayer1.id })
-    const { result } = renderHook(() =>
-      useSnackbar({
-        actorRef,
-        match,
-      })
-    )
-
-    const showNotification = vi.fn()
-
-    vi.spyOn(result.current, 'showNotification').mockImplementation(
-      showNotification
-    )
-
-    const payload: ShellNotificationPayload[ShellNotificationType.CARD_DISCARDED] =
-      {
-        cardDiscarded: stubSprinkler,
-      }
-
-    const send = actorRef.send as unknown as MockInstance<
-      (event: MatchEvents) => void
-    >
-    const matchEventPayload = send.mock.calls[0]![0]
-
-    assertEvent(matchEventPayload, MatchEvent.SET_SHELL)
-
-    act(() => {
-      matchEventPayload.shell.triggerNotification({
-        type: ShellNotificationType.CARD_DISCARDED,
-        payload,
-      })
-    })
-
-    expect(result.current.snackbarProps.message).toEqual(
-      `You discarded ${payload.cardDiscarded.name}`
-    )
-    expect(result.current.snackbarProps.severity).toEqual('info')
-  })
-
-  it('should show the correct CARD_DISCARDED notification message when non-session owner discards a planted card', () => {
-    match = updateMatch(match, { sessionOwnerPlayerId: stubPlayer2.id })
-    const { result } = renderHook(() =>
-      useSnackbar({
-        actorRef,
-        match,
-      })
-    )
-
-    const showNotification = vi.fn()
-
-    vi.spyOn(result.current, 'showNotification').mockImplementation(
-      showNotification
-    )
-
-    const payload: ShellNotificationPayload[ShellNotificationType.CARD_DISCARDED] =
-      {
-        cardDiscarded: stubSprinkler,
-      }
-
-    const send = actorRef.send as unknown as MockInstance<
-      (event: MatchEvents) => void
-    >
-    const matchEventPayload = send.mock.calls[0]![0]
-
-    assertEvent(matchEventPayload, MatchEvent.SET_SHELL)
-
-    act(() => {
-      matchEventPayload.shell.triggerNotification({
-        type: ShellNotificationType.CARD_DISCARDED,
-        payload,
-      })
-    })
-
-    expect(result.current.snackbarProps.message).toEqual(
-      `Fun Animal discarded ${payload.cardDiscarded.name}`
-    )
-    expect(result.current.snackbarProps.severity).toEqual('info')
-  })
-
-  it('should update snackbarProps correctly with showNotification', () => {
+  it('should call showNotification on showNotification call', () => {
     const { result } = renderHook(() =>
       useSnackbar({
         actorRef,
@@ -552,28 +522,9 @@ describe('useSnackbar Hook', () => {
       result.current.showNotification('Test Message', 'success')
     })
 
-    expect(result.current.snackbarProps.message).toBe('Test Message')
-    expect(result.current.snackbarProps.severity).toBe('success')
-  })
-
-  it('should clear the notification message when onClose is called', () => {
-    const { result } = renderHook(() =>
-      useSnackbar({
-        actorRef,
-        match,
-      })
+    expect(showNotificationMock).toHaveBeenLastCalledWith(
+      'Test Message',
+      'success'
     )
-
-    act(() => {
-      result.current.showNotification('Test Message', 'success')
-    })
-
-    expect(result.current.snackbarProps.message).toBe('Test Message')
-
-    act(() => {
-      result.current.snackbarProps.onClose()
-    })
-
-    expect(result.current.snackbarProps.message).toBe(emptyNotificationMessage)
   })
 })

--- a/src/ui/components/Match/useSnackbar.ts
+++ b/src/ui/components/Match/useSnackbar.ts
@@ -1,12 +1,11 @@
 import { AlertColor } from '@mui/material'
 import { funAnimalName } from 'fun-animal-names'
-import { ReactNode, useCallback, useEffect, useState } from 'react'
+import { ReactNode, useCallback, useEffect } from 'react'
 import reactNodeToString from 'react-node-to-string'
 
 import { MatchEvent, IMatch, ShellNotificationType } from '../../../game/types'
 import { isDebugEnabled } from '../../config/constants'
-
-import { emptyNotificationMessage, SnackbarProps } from '../Snackbar'
+import { useNotification } from '../../context/NotificationContext'
 
 import { ActorContext } from './ActorContext'
 
@@ -21,16 +20,7 @@ export const useSnackbar = ({
   actorRef: ReturnType<typeof ActorContext.useActorRef>
   match: IMatch
 }) => {
-  const [snackbarProps, setSnackbarProps] = useState<SnackbarProps>({
-    message: '',
-    severity: 'info',
-    onClose: () => {
-      setSnackbarProps(prev => ({
-        ...prev,
-        message: emptyNotificationMessage,
-      }))
-    },
-  })
+  const { showNotification: triggerGlobalNotification } = useNotification()
 
   const showNotification = useCallback(
     (message: ReactNode, severity: AlertColor) => {
@@ -38,9 +28,9 @@ export const useSnackbar = ({
         console.debug(`Notification: ${reactNodeToString(message)}`)
       }
 
-      setSnackbarProps(prev => ({ ...prev, message, severity }))
+      triggerGlobalNotification(message, severity)
     },
-    [setSnackbarProps]
+    [triggerGlobalNotification]
   )
 
   const isSessionOwner = match.currentPlayerId === match.sessionOwnerPlayerId
@@ -174,5 +164,5 @@ export const useSnackbar = ({
     })
   }, [actorRef, match.currentPlayerId, isSessionOwner, showNotification])
 
-  return { showNotification, snackbarProps }
+  return { showNotification }
 }

--- a/src/ui/context/NotificationContext/NotificationContext.test.tsx
+++ b/src/ui/context/NotificationContext/NotificationContext.test.tsx
@@ -1,0 +1,102 @@
+import { render, renderHook, screen } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import { vi } from 'vitest'
+
+import { assertIsNonNullable } from '../../../game/types/guards'
+import * as SnackbarModule from '../../components/Snackbar'
+
+import { NotificationProvider, useNotification } from './NotificationContext'
+
+vi.mock('../../components/Snackbar', () => ({
+  emptyNotificationMessage: '',
+  Snackbar: vi.fn(() => <div data-testid="mock-snackbar" />),
+}))
+
+const TestConsumer = () => {
+  const { showNotification } = useNotification()
+
+  return (
+    <button
+      data-testid="show-button"
+      onClick={() => showNotification('Test Notification', 'success')}
+    >
+      Show
+    </button>
+  )
+}
+
+describe('NotificationContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws error when showNotification is called outside NotificationProvider', () => {
+    const { result } = renderHook(() => useNotification())
+
+    expect(() => result.current.showNotification('test')).toThrow(
+      'Calling showNotification outside of NotificationProvider'
+    )
+  })
+
+  it('always mounts Snackbar with an empty message initially', () => {
+    render(
+      <NotificationProvider>
+        <div data-testid="child">Child Content</div>
+      </NotificationProvider>
+    )
+
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-snackbar')).toBeInTheDocument()
+    expect(vi.mocked(SnackbarModule.Snackbar)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: '' }),
+      expect.anything()
+    )
+  })
+
+  it('displays Snackbar when showNotification is called', () => {
+    render(
+      <NotificationProvider>
+        <TestConsumer />
+      </NotificationProvider>
+    )
+
+    act(() => {
+      screen.getByTestId('show-button').click()
+    })
+
+    expect(screen.getByTestId('mock-snackbar')).toBeInTheDocument()
+    expect(vi.mocked(SnackbarModule.Snackbar)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Test Notification',
+        severity: 'success',
+      }),
+      expect.anything()
+    )
+  })
+
+  it('resets the message when onClose is called, without unmounting Snackbar', () => {
+    render(
+      <NotificationProvider>
+        <TestConsumer />
+      </NotificationProvider>
+    )
+
+    act(() => {
+      screen.getByTestId('show-button').click()
+    })
+
+    const snackbarProps = vi.mocked(SnackbarModule.Snackbar).mock.calls[0]?.[0]
+
+    assertIsNonNullable(snackbarProps)
+
+    act(() => {
+      snackbarProps.onClose()
+    })
+
+    expect(screen.getByTestId('mock-snackbar')).toBeInTheDocument()
+    expect(vi.mocked(SnackbarModule.Snackbar)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ message: '' }),
+      expect.anything()
+    )
+  })
+})

--- a/src/ui/context/NotificationContext/NotificationContext.tsx
+++ b/src/ui/context/NotificationContext/NotificationContext.tsx
@@ -1,0 +1,58 @@
+import { AlertColor } from '@mui/material/Alert'
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+
+import { emptyNotificationMessage, Snackbar } from '../../components/Snackbar'
+
+import { NotificationContextProps } from './types'
+
+export const NotificationContext = createContext<NotificationContextProps>({
+  showNotification: () => {
+    throw new Error('Calling showNotification outside of NotificationProvider')
+  },
+})
+
+export const NotificationProvider = ({ children }: { children: ReactNode }) => {
+  const [notificationState, setNotificationState] = useState<{
+    message: ReactNode
+    severity: AlertColor
+  }>({
+    message: emptyNotificationMessage,
+    severity: 'info',
+  })
+
+  const handleClose = useCallback(() => {
+    setNotificationState(prev => ({
+      ...prev,
+      message: emptyNotificationMessage,
+    }))
+  }, [])
+
+  const showNotification = useCallback(
+    (message: ReactNode, severity: AlertColor = 'info') => {
+      setNotificationState({ message, severity })
+    },
+    []
+  )
+
+  const contextValue = useMemo(() => ({ showNotification }), [showNotification])
+
+  return (
+    <NotificationContext.Provider value={contextValue}>
+      {children}
+      <Snackbar
+        message={notificationState.message}
+        severity={notificationState.severity}
+        onClose={handleClose}
+      />
+    </NotificationContext.Provider>
+  )
+}
+
+export const useNotification = () => useContext(NotificationContext)

--- a/src/ui/context/NotificationContext/index.ts
+++ b/src/ui/context/NotificationContext/index.ts
@@ -1,0 +1,2 @@
+export * from './NotificationContext'
+export * from './types'

--- a/src/ui/context/NotificationContext/types.ts
+++ b/src/ui/context/NotificationContext/types.ts
@@ -1,0 +1,6 @@
+import { AlertColor } from '@mui/material/Alert'
+import { ReactNode } from 'react'
+
+export interface NotificationContextProps {
+  showNotification: (message: ReactNode, severity?: AlertColor) => void
+}

--- a/src/ui/pages/BuildDeck/BuildDeck.stories.tsx
+++ b/src/ui/pages/BuildDeck/BuildDeck.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MemoryRouter } from 'react-router-dom'
+import { spyOn } from 'storybook/test'
+
+import { storage } from '../../../services/StorageService'
+import { NotificationProvider } from '../../context/NotificationContext'
+
+import { BuildDeck } from './BuildDeck'
+
+const meta: Meta<typeof BuildDeck> = {
+  title: 'Pages/BuildDeck',
+  component: BuildDeck,
+  decorators: [
+    Story => (
+      <NotificationProvider>
+        <MemoryRouter>
+          <Story />
+        </MemoryRouter>
+      </NotificationProvider>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof BuildDeck>
+
+export const Default: Story = {
+  decorators: [
+    Story => {
+      spyOn(storage, 'saveDeck').mockResolvedValue(undefined)
+
+      return <Story />
+    },
+  ],
+}
+
+export const SaveError: Story = {
+  decorators: [
+    Story => {
+      spyOn(storage, 'saveDeck').mockRejectedValue(
+        new Error('Failed to save deck')
+      )
+
+      return <Story />
+    },
+  ],
+}

--- a/src/ui/pages/BuildDeck/BuildDeck.test.tsx
+++ b/src/ui/pages/BuildDeck/BuildDeck.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import { MemoryRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+
+import { DeserializedDeck } from '../../../services/StorageService'
+import { DeckBuilderProps } from '../../components/DeckBuilder/types'
+
+import { BuildDeck } from './BuildDeck'
+
+const saveDeckMock = vi.fn<(deck: DeserializedDeck) => Promise<void>>()
+
+vi.mock('../../../services/StorageService', async importOriginal => {
+  const actual = await importOriginal<
+    typeof import('../../../services/StorageService')
+  >()
+
+  return {
+    ...actual,
+    storage: {
+      saveDeck: (deck: DeserializedDeck) => saveDeckMock(deck),
+    },
+  }
+})
+
+vi.mock('../../components/DeckBuilder', () => ({
+  DeckBuilder: vi.fn(({ onDone, isLoading }: DeckBuilderProps) => (
+    <div data-testid="mock-deck-builder">
+      <button
+        data-testid="done-button"
+        onClick={() => void onDone(new Map())}
+        disabled={isLoading}
+      >
+        Done
+      </button>
+    </div>
+  )),
+}))
+
+const showNotificationMock = vi.fn()
+
+vi.mock('../../context/NotificationContext', async importOriginal => {
+  const actual = await importOriginal<
+    typeof import('../../context/NotificationContext')
+  >()
+
+  return {
+    ...actual,
+    useNotification: () => ({
+      showNotification: showNotificationMock,
+    }),
+  }
+})
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+describe('BuildDeck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders DeckBuilder component', () => {
+    render(
+      <MemoryRouter>
+        <BuildDeck />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('mock-deck-builder')).toBeInTheDocument()
+  })
+
+  it('navigates to main menu with notification on successful deck save', async () => {
+    saveDeckMock.mockResolvedValueOnce()
+
+    render(
+      <MemoryRouter>
+        <BuildDeck />
+      </MemoryRouter>
+    )
+
+    await act(async () => {
+      screen.getByTestId('done-button').click()
+      await Promise.resolve()
+    })
+
+    expect(saveDeckMock).toHaveBeenCalledWith(new Map())
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      'Deck saved successfully',
+      'success'
+    )
+    expect(mockNavigate).toHaveBeenCalledWith('/')
+  })
+
+  it('triggers error notification when saving deck fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    saveDeckMock.mockRejectedValueOnce(new Error('Storage error'))
+
+    render(
+      <MemoryRouter>
+        <BuildDeck />
+      </MemoryRouter>
+    )
+
+    await act(async () => {
+      screen.getByTestId('done-button').click()
+      await Promise.resolve()
+    })
+
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      'Failed to save deck',
+      'error'
+    )
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/src/ui/pages/BuildDeck/BuildDeck.tsx
+++ b/src/ui/pages/BuildDeck/BuildDeck.tsx
@@ -3,17 +3,26 @@ import { useAsyncFn } from 'react-use'
 
 import { DeserializedDeck, storage } from '../../../services/StorageService'
 import { DeckBuilder } from '../../components/DeckBuilder'
+import { useNotification } from '../../context/NotificationContext'
+import { AppRoute } from '../../types'
 
 export const BuildDeck = () => {
   const navigate = useNavigate()
+  const { showNotification } = useNotification()
 
   const [state, saveDeck] = useAsyncFn(
     async (deck: DeserializedDeck) => {
-      await storage.saveDeck(deck)
-      void navigate('/', { state: { notification: 'Deck saved successfully' } })
-      // TODO: Handle errors
+      try {
+        await storage.saveDeck(deck)
+
+        showNotification('Deck saved successfully', 'success')
+        void navigate(AppRoute.ROOT)
+      } catch (e) {
+        console.error(e)
+        showNotification('Failed to save deck', 'error')
+      }
     },
-    [navigate]
+    [navigate, showNotification]
   )
 
   return <DeckBuilder onDone={saveDeck} isLoading={state.loading} />

--- a/src/ui/pages/MainMenu/MainMenu.test.tsx
+++ b/src/ui/pages/MainMenu/MainMenu.test.tsx
@@ -1,15 +1,23 @@
 import { render, screen } from '@testing-library/react'
-import { act } from 'react-dom/test-utils'
 import { MemoryRouter } from 'react-router-dom'
 import { vi } from 'vitest'
 
-import * as SnackbarModule from '../../components/Snackbar'
-
 import { MainMenu } from './MainMenu'
 
-vi.mock('../../components/Snackbar', () => ({
-  Snackbar: vi.fn(() => <div data-testid="mock-snackbar" />),
-}))
+const showNotificationMock = vi.fn()
+
+vi.mock('../../context/NotificationContext', async importOriginal => {
+  const actual = await importOriginal<
+    typeof import('../../context/NotificationContext')
+  >()
+
+  return {
+    ...actual,
+    useNotification: () => ({
+      showNotification: showNotificationMock,
+    }),
+  }
+})
 
 const mockNavigate = vi.fn()
 
@@ -37,10 +45,10 @@ describe('MainMenu', () => {
     expect(screen.getByText('Farmhand Shuffle')).toBeInTheDocument()
     expect(screen.getByText('Play a match')).toBeInTheDocument()
     expect(screen.getByText('Build a deck')).toBeInTheDocument()
-    expect(screen.queryByTestId('mock-snackbar')).not.toBeInTheDocument()
+    expect(showNotificationMock).not.toHaveBeenCalled()
   })
 
-  it('displays Snackbar when notification state is provided', () => {
+  it('triggers notification and clears location state when notification state is provided', () => {
     render(
       <MemoryRouter
         initialEntries={[
@@ -51,33 +59,7 @@ describe('MainMenu', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByTestId('mock-snackbar')).toBeInTheDocument()
-    expect(SnackbarModule.Snackbar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Success!',
-        severity: 'success',
-      }),
-      expect.anything()
-    )
-  })
-
-  it('clears location state when Snackbar is closed', () => {
-    render(
-      <MemoryRouter
-        initialEntries={[
-          { pathname: '/', state: { notification: 'Success!' } },
-        ]}
-      >
-        <MainMenu />
-      </MemoryRouter>
-    )
-
-    const snackbarProps = vi.mocked(SnackbarModule.Snackbar).mock.calls[0]?.[0]
-
-    act(() => {
-      snackbarProps?.onClose()
-    })
-
+    expect(showNotificationMock).toHaveBeenCalledWith('Success!', 'success')
     expect(mockNavigate).toHaveBeenCalledWith('.', { replace: true, state: {} })
   })
 })

--- a/src/ui/pages/MainMenu/MainMenu.test.tsx
+++ b/src/ui/pages/MainMenu/MainMenu.test.tsx
@@ -1,40 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { vi } from 'vitest'
 
 import { MainMenu } from './MainMenu'
 
-const showNotificationMock = vi.fn()
-
-vi.mock('../../context/NotificationContext', async importOriginal => {
-  const actual = await importOriginal<
-    typeof import('../../context/NotificationContext')
-  >()
-
-  return {
-    ...actual,
-    useNotification: () => ({
-      showNotification: showNotificationMock,
-    }),
-  }
-})
-
-const mockNavigate = vi.fn()
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom')
-
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  }
-})
-
 describe('MainMenu', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   it('renders correctly', () => {
     render(
       <MemoryRouter>
@@ -45,21 +14,5 @@ describe('MainMenu', () => {
     expect(screen.getByText('Farmhand Shuffle')).toBeInTheDocument()
     expect(screen.getByText('Play a match')).toBeInTheDocument()
     expect(screen.getByText('Build a deck')).toBeInTheDocument()
-    expect(showNotificationMock).not.toHaveBeenCalled()
-  })
-
-  it('triggers notification and clears location state when notification state is provided', () => {
-    render(
-      <MemoryRouter
-        initialEntries={[
-          { pathname: '/', state: { notification: 'Success!' } },
-        ]}
-      >
-        <MainMenu />
-      </MemoryRouter>
-    )
-
-    expect(showNotificationMock).toHaveBeenCalledWith('Success!', 'success')
-    expect(mockNavigate).toHaveBeenCalledWith('.', { replace: true, state: {} })
   })
 })

--- a/src/ui/pages/MainMenu/MainMenu.tsx
+++ b/src/ui/pages/MainMenu/MainMenu.tsx
@@ -1,24 +1,9 @@
 import { Box, Button, Stack, Typography } from '@mui/material'
-import { useEffect } from 'react'
-import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
-import { useNotification } from '../../context/NotificationContext'
-import { isLocationStateWithNotification } from '../../type-guards'
 import { AppRoute } from '../../types'
 
 export const MainMenu = () => {
-  const location = useLocation()
-  const navigate = useNavigate()
-  const { showNotification } = useNotification()
-
-  useEffect(() => {
-    if (isLocationStateWithNotification(location.state)) {
-      showNotification(location.state.notification, 'success')
-      // Clear the location state so the notification doesn't reappear on refresh
-      void navigate('.', { replace: true, state: {} })
-    }
-  }, [location.state, navigate, showNotification])
-
   return (
     <Box
       sx={{

--- a/src/ui/pages/MainMenu/MainMenu.tsx
+++ b/src/ui/pages/MainMenu/MainMenu.tsx
@@ -1,30 +1,23 @@
 import { Box, Button, Stack, Typography } from '@mui/material'
-import { useCallback, useState } from 'react'
+import { useEffect } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
-import { Snackbar } from '../../components/Snackbar'
+import { useNotification } from '../../context/NotificationContext'
 import { isLocationStateWithNotification } from '../../type-guards'
 import { AppRoute } from '../../types'
 
 export const MainMenu = () => {
   const location = useLocation()
   const navigate = useNavigate()
+  const { showNotification } = useNotification()
 
-  // Extract the notification from location state, if any.
-  const state = isLocationStateWithNotification(location.state)
-    ? location.state
-    : null
-  const initialNotification = state?.notification ?? ''
-
-  const [notificationMessage, setNotificationMessage] =
-    useState(initialNotification)
-
-  const handleSnackbarClose = useCallback(() => {
-    setNotificationMessage('')
-
-    // Clear the location state so the notification doesn't reappear on refresh
-    void navigate('.', { replace: true, state: {} })
-  }, [navigate])
+  useEffect(() => {
+    if (isLocationStateWithNotification(location.state)) {
+      showNotification(location.state.notification, 'success')
+      // Clear the location state so the notification doesn't reappear on refresh
+      void navigate('.', { replace: true, state: {} })
+    }
+  }, [location.state, navigate, showNotification])
 
   return (
     <Box
@@ -58,13 +51,6 @@ export const MainMenu = () => {
           </Button>
         </Stack>
       </Stack>
-      {notificationMessage && (
-        <Snackbar
-          message={notificationMessage}
-          severity="success"
-          onClose={handleSnackbarClose}
-        />
-      )}
     </Box>
   )
 }

--- a/src/ui/type-guards.test.ts
+++ b/src/ui/type-guards.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isLocationStateWithNotification, isSxArray } from './type-guards'
+import { isSxArray } from './type-guards'
 
 describe('type-guards', () => {
   describe('isSxArray', () => {
@@ -16,40 +16,6 @@ describe('type-guards', () => {
       expect(
         isSxArray(null as unknown as Parameters<typeof isSxArray>[0])
       ).toBe(false)
-    })
-  })
-
-  describe('isLocationStateWithNotification', () => {
-    it('returns true for an object with a string notification', () => {
-      expect(isLocationStateWithNotification({ notification: 'Hello' })).toBe(
-        true
-      )
-    })
-
-    it('returns false for an empty object', () => {
-      expect(isLocationStateWithNotification({})).toBe(false)
-    })
-
-    it('returns false for an object with undefined notification', () => {
-      expect(isLocationStateWithNotification({ notification: undefined })).toBe(
-        false
-      )
-    })
-
-    it('returns false for null', () => {
-      expect(isLocationStateWithNotification(null)).toBe(false)
-    })
-
-    it('returns false for a non-object', () => {
-      expect(isLocationStateWithNotification('string')).toBe(false)
-      expect(isLocationStateWithNotification(123)).toBe(false)
-      expect(isLocationStateWithNotification(true)).toBe(false)
-      expect(isLocationStateWithNotification(undefined)).toBe(false)
-    })
-
-    it('returns false for an object with a non-string notification', () => {
-      expect(isLocationStateWithNotification({ notification: 123 })).toBe(false)
-      expect(isLocationStateWithNotification({ notification: {} })).toBe(false)
     })
   })
 })

--- a/src/ui/type-guards.ts
+++ b/src/ui/type-guards.ts
@@ -2,8 +2,6 @@ import { SxProps } from '@mui/material/styles'
 import { Theme } from '@mui/material/styles/createTheme'
 import { SystemStyleObject } from '@mui/system/styleFunctionSx/styleFunctionSx'
 
-import { ILocationStateWithNotification } from './types'
-
 // NOTE: This is a workaround for unhelpful TypeScript behavior that conflicts
 // with MUI idioms.
 // See: https://github.com/mui/material-ui/issues/37730#issuecomment-2218304523
@@ -15,14 +13,4 @@ export const isSxArray = (
   | ((theme: Theme) => SystemStyleObject<Theme>)
 > => {
   return Array.isArray(sx)
-}
-
-export const isLocationStateWithNotification = (
-  state: unknown
-): state is ILocationStateWithNotification => {
-  if (state === null || typeof state !== 'object') {
-    return false
-  }
-
-  return 'notification' in state && typeof state.notification === 'string'
 }

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -9,7 +9,3 @@ export enum AppRoute {
   MATCH = '/match',
   BUILD_DECK = '/build-deck',
 }
-
-export interface ILocationStateWithNotification {
-  notification: string
-}


### PR DESCRIPTION
### What this PR does

Introduces a global `NotificationContext`/`NotificationProvider` so notifications can be shown from anywhere in the app via a single `showNotification` call, instead of components managing their own `Snackbar` state or passing notification messages through router location state.

- `useSnackbar` (used by `Match`) and `BuildDeck` now both call the shared `showNotification` from `NotificationContext` instead of managing local `Snackbar` props.
- `Snackbar` is always mounted by `NotificationProvider` (relying on its own internal `isOpen`/transition state) so its close animation isn't cut short, and the empty-message sentinel reuses `Snackbar`'s exported `emptyNotificationMessage` constant instead of a duplicated `''` literal.
- Removed the now-dead router-state notification path in `MainMenu` (`isLocationStateWithNotification` / `ILocationStateWithNotification`), which was only used by `BuildDeck`'s old navigate-with-state flow.
- Added `BuildDeck.test.tsx` and `BuildDeck.stories.tsx`.

### How this change can be validated

- `npm test` — full suite passes, including updated `NotificationContext`, `MainMenu`, `type-guards`, and new `BuildDeck` tests.
- `npm run check:types` and `npm run check:lint` pass.
- Manually: save a deck in Build a Deck and confirm the success/error snackbar appears and animates in/out correctly; trigger in-match notifications (draw, harvest, etc.) and confirm they still slide in and out smoothly.

### Questions or concerns about this change

None.

### Additional information

<!-- Share screenshots, video previews, or any other information that would be helpful for reviewers. -->